### PR TITLE
feat(nav): theme selector dropdown replaces DS button

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,5 +1,145 @@
 import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
+import { useState, useEffect, useRef, type ReactNode } from "react";
+import { Check, ChevronDown, Moon, Sun, Zap } from "lucide-react";
 import { SymbolSelector } from "@/ui/symbol-selector";
+
+type ThemeId = "soft" | "night-city" | "maelstrom" | "corpo-ice" | "netrunner";
+type ModeId = "dark" | "light" | "vibrant";
+
+const THEME_STORAGE_KEY = "trading-theme";
+const MODE_STORAGE_KEY  = "trading-mode";
+
+const THEMES: { id: ThemeId; label: string; accent: string }[] = [
+  { id: "soft",       label: "Soft",       accent: "oklch(0.62 0.22 280)" },
+  { id: "night-city", label: "Night City", accent: "oklch(0.68 0.22 95)"  },
+  { id: "maelstrom",  label: "Maelstrom",  accent: "oklch(0.56 0.28 316)" },
+  { id: "corpo-ice",  label: "Corpo Ice",  accent: "oklch(0.88 0.18 215)" },
+  { id: "netrunner",  label: "Netrunner",  accent: "oklch(0.62 0.22 280)" },
+];
+
+const MODES: { id: ModeId; icon: ReactNode; label: string }[] = [
+  { id: "dark",    icon: <Moon size={11} />,  label: "Dark"    },
+  { id: "light",   icon: <Sun size={11} />,   label: "Light"   },
+  { id: "vibrant", icon: <Zap size={11} />,   label: "Vibrant" },
+];
+
+function applyTheme(theme: ThemeId, mode: ModeId) {
+  const el = document.documentElement;
+  el.setAttribute("data-theme", theme);
+  el.setAttribute("data-mode", mode);
+  if (mode === "light") el.classList.remove("dark");
+  else el.classList.add("dark");
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+  localStorage.setItem(MODE_STORAGE_KEY, mode);
+}
+
+function ThemeDropdown() {
+  const [theme, setThemeState] = useState<ThemeId>("night-city");
+  const [mode, setModeState]   = useState<ModeId>("dark");
+  const [open, setOpen]        = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const t = (localStorage.getItem(THEME_STORAGE_KEY) as ThemeId | null)
+      ?? (document.documentElement.getAttribute("data-theme") as ThemeId | null)
+      ?? "night-city";
+    const m = (localStorage.getItem(MODE_STORAGE_KEY) as ModeId | null)
+      ?? (document.documentElement.getAttribute("data-mode") as ModeId | null)
+      ?? "dark";
+    if (THEMES.some((x) => x.id === t)) setThemeState(t as ThemeId);
+    setModeState(m as ModeId);
+  }, []);
+
+  useEffect(() => {
+    function onOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener("mousedown", onOutside);
+    return () => document.removeEventListener("mousedown", onOutside);
+  }, []);
+
+  const current = THEMES.find((t) => t.id === theme);
+
+  function selectTheme(t: ThemeId) {
+    setThemeState(t);
+    applyTheme(t, mode);
+    setOpen(false);
+  }
+
+  function selectMode(m: ModeId) {
+    setModeState(m);
+    applyTheme(theme, m);
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex items-center gap-1.5 px-2 py-1 rounded border border-border/40 hover:border-border transition-colors cursor-pointer"
+        style={{ color: "var(--color-muted-foreground)" }}
+      >
+        <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: current?.accent }} />
+        <span className="text-[10px] font-mono uppercase tracking-wider">{current?.label ?? theme}</span>
+        <ChevronDown
+          size={10}
+          style={{ transition: "transform 0.15s", transform: open ? "rotate(180deg)" : "rotate(0deg)" }}
+        />
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 w-44 rounded-md border border-border shadow-lg z-50 overflow-hidden"
+          style={{ backgroundColor: "var(--color-card)" }}
+        >
+          {/* Theme list */}
+          <div className="py-1">
+            {THEMES.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => selectTheme(t.id)}
+                className="w-full flex items-center gap-2 px-3 py-1.5 text-xs hover:bg-muted transition-colors cursor-pointer text-left"
+                style={{ color: t.id === theme ? "var(--primary)" : "var(--color-foreground)" }}
+              >
+                <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: t.accent }} />
+                <span className="flex-1 font-mono">{t.label}</span>
+                {t.id === theme && <Check size={10} />}
+              </button>
+            ))}
+          </div>
+
+          {/* Mode row */}
+          <div className="border-t border-border/40 px-3 py-2 flex items-center gap-1">
+            {MODES.map((m) => (
+              <button
+                key={m.id}
+                onClick={() => selectMode(m.id)}
+                title={m.label}
+                className="flex items-center justify-center flex-1 h-6 rounded cursor-pointer transition-colors"
+                style={{
+                  backgroundColor: m.id === mode ? "var(--primary)" : "transparent",
+                  color: m.id === mode ? "var(--primary-foreground)" : "var(--color-muted-foreground)",
+                }}
+              >
+                {m.icon}
+              </button>
+            ))}
+          </div>
+
+          {/* Divider + DS link */}
+          <div className="border-t border-border/40 py-1">
+            <Link
+              to="/design-system"
+              onClick={() => setOpen(false)}
+              className="flex items-center px-3 py-1.5 text-[10px] font-mono uppercase tracking-wider text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-pointer"
+            >
+              Design System
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -59,14 +199,7 @@ function RootComponent() {
 
           <div className="w-px h-5 bg-border mx-1" />
 
-          {/* DS link */}
-          <Link
-            to="/design-system"
-            className="text-[10px] font-mono uppercase tracking-wider px-2 py-1 rounded border border-border/40 transition-colors hover:border-border"
-            style={{ color: "var(--color-muted-foreground)" }}
-          >
-            DS
-          </Link>
+          <ThemeDropdown />
 
           {/* Live indicator */}
           <div className="flex items-center gap-1.5 ml-1">


### PR DESCRIPTION
Replaces the static "DS" button in the navbar with a theme selector dropdown.

## Changes
- `src/routes/__root.tsx`: adds `ThemeDropdown` component, removes static DS link

## Features
- 5 theme swatches (Soft, Night City, Maelstrom, Corpo Ice, Netrunner) with accent color dots
- Active theme highlighted with checkmark
- Mode toggle row: Dark (Moon) / Light (Sun) / Vibrant (Zap) icon buttons
- Active mode highlighted with `--primary` background
- Design System link preserved behind a divider at the bottom
- Persists to `localStorage` (`trading-theme`, `trading-mode`) and applies instantly
- Dropdown closes on outside click

Closes #6