### PR TITLE
ci(workflows): fix pr-hygiene and dco for main-only repo; add test coverage

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,57 @@
+# Label definitions for trading-engine
+# Apply with: gh label import --labels .github/labels.yml
+
+# Type
+- name: "enhancement"
+  color: "0075ca"
+  description: "New feature or improvement"
+
+- name: "bug"
+  color: "d73a4a"
+  description: "Something isn't working"
+
+- name: "fix"
+  color: "e4e669"
+  description: "Bug fix"
+
+- name: "feat"
+  color: "1A7F5E"
+  description: "New capability"
+
+- name: "refactor"
+  color: "e4e669"
+  description: "Code restructure without behavior change"
+
+- name: "test"
+  color: "0e8a16"
+  description: "Test additions or fixes"
+
+- name: "chore"
+  color: "6B7280"
+  description: "Build, CI, dependencies, tooling"
+
+- name: "documentation"
+  color: "0075ca"
+  description: "Documentation changes"
+
+- name: "performance"
+  color: "F59E0B"
+  description: "Performance improvement"
+
+# Domain
+- name: "design-system"
+  color: "7B5EA7"
+  description: "Design system — tokens, components, themes"
+
+- name: "ui"
+  color: "EC4899"
+  description: "UI / visual changes"
+
+# Status
+- name: "status:stale"
+  color: "E5E7EB"
+  description: "Inactive for 30+ days"
+
+- name: "status:blocked"
+  color: "FCA5A5"
+  description: "Blocked — cannot proceed"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,42 @@
+name: DCO Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  dco:
+    name: DCO sign-off
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    # Skip release-please automation branches.
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    steps:
+      - name: Check DCO sign-off on all commits
+        uses: actions/github-script@v7
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const missing = commits
+              .filter(c => !c.commit.message.includes('Signed-off-by:'))
+              .map(c => `  ${c.sha.slice(0, 7)} ${c.commit.message.split('\n')[0]}`);
+
+            if (missing.length > 0) {
+              core.setFailed(
+                `${missing.length} commit(s) are missing a DCO Signed-off-by line:\n${missing.join('\n')}\n\n` +
+                `To fix, amend each commit with:\n` +
+                `  git commit --amend -s\n\n` +
+                `Or use 'git commit -s' for all future commits.\n` +
+                `See CONTRIBUTING.md for details.`
+              );
+            }

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -1,0 +1,147 @@
+name: PR Hygiene
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled, milestoned, demilestoned]
+
+jobs:
+  skip-check:
+    name: Skip check
+    runs-on: ubuntu-latest
+    if: startsWith(github.head_ref, 'release-please--')
+    steps:
+      - run: echo "Skipping hygiene checks for release-please branch"
+
+  pr-hygiene-title:
+    name: PR title format
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    steps:
+      - name: Check PR title format
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const pattern = /^(feat|fix|chore|docs|test|refactor|perf|ci)\([a-z][a-z0-9-]+\): .{3,}/;
+            if (!pattern.test(title)) {
+              core.setFailed(
+                `PR title "${title}" doesn't match required format.\n` +
+                `Expected: type(scope): description\n` +
+                `Examples:\n` +
+                `  feat(order-book): add independent bid/ask scroll\n` +
+                `  fix(tokens): map trading vars to @theme inline\n` +
+                `  chore(ci): fix workflow triggers for main-only repo\n` +
+                `Valid types: feat, fix, chore, docs, test, refactor, perf, ci`
+              );
+            } else {
+              core.notice(`✅ PR title format valid: "${title}"`);
+            }
+
+  pr-hygiene-labels:
+    name: Required labels
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    steps:
+      - name: Check required labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            const validLabels = ['enhancement', 'bug', 'refactor', 'chore', 'design-system', 'documentation', 'performance', 'test'];
+            const hasValid = labels.some(l => validLabels.includes(l));
+            if (!hasValid) {
+              core.setFailed(
+                `PR is missing a required label.\n` +
+                `Add one of: ${validLabels.join(', ')}\n` +
+                `Labels describe what kind of change this PR contains.`
+              );
+            } else {
+              const matched = labels.filter(l => validLabels.includes(l));
+              core.notice(`✅ Labels present: ${matched.join(', ')}`);
+            }
+
+  pr-hygiene-milestone:
+    name: Milestone assignment
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    steps:
+      - name: Check milestone assignment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const milestone = context.payload.pull_request.milestone;
+            const isReleaseBranch = /^release\/v\d+\.\d+\.\d+/.test(branch);
+
+            if (!isReleaseBranch) {
+              core.notice(
+                `✅ Development PR — milestone optional (assigned at release time).`
+              );
+              return;
+            }
+            if (milestone) {
+              core.notice(`✅ Release PR has milestone: ${milestone.title}`);
+              return;
+            }
+            core.setFailed(
+              `Release PR "${branch}" is missing a required milestone.\n` +
+              `Assign the target version milestone before merging.`
+            );
+
+  pr-hygiene-docs:
+    name: Documentation freshness
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
+    steps:
+      - name: Check docs freshness on feat PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            if (!title.startsWith('feat(')) {
+              core.notice(`ℹ️  Not a feat PR — docs check skipped.`);
+              return;
+            }
+
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const changed = files.map(f => f.filename);
+
+            const touchesSrc     = changed.some(f => f.startsWith('src/'));
+            const touchesReadme  = changed.includes('README.md');
+            const touchesRoadmap = changed.includes('ROADMAP.md');
+
+            if (!touchesSrc) {
+              core.notice(`✅ Feat PR doesn't touch src/ — docs check not required.`);
+              return;
+            }
+
+            const failures = [];
+            if (!touchesRoadmap) failures.push('ROADMAP.md not updated');
+            if (!touchesReadme)  failures.push('README.md not updated (if applicable)');
+
+            if (failures.length > 0) {
+              core.warning(
+                `⚠️  Feat PR modifies src/ but docs may need updating:\n` +
+                failures.map(f => `  • ${f}`).join('\n') + '\n' +
+                `Update ROADMAP.md to reflect progress, and README.md if behaviour changed.\n` +
+                `(This is a warning — update if relevant, skip if docs don't apply.)`
+              );
+            } else {
+              core.notice(`✅ Docs up-to-date (ROADMAP.md and README.md updated).`);
+            }
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: pnpm
-
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
 
       - run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test + Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm coverage
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 14

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.1",
   "type": "module",
   "description": "Real-time trading engine simulator with live Binance market data",
+  "packageManager": "pnpm@10.24.0",
   "engines": {
     "node": ">=22"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "lint": "biome check src/ && eslint src/",
     "format": "biome format --write src/",
     "check": "biome check src/",


### PR DESCRIPTION
## Summary

Three of five CI workflows had incorrect configuration — built for a different repo (Go CLI with `develop` branch). This PR fixes them to match this project.

## Changes

### `test.yml` — rewritten from dead stub
- Was: `echo "TODO: add build command"` on every push/PR
- Now: Node 22 + pnpm setup → `pnpm coverage` (vitest run --coverage) → uploads coverage artifact (14-day retention)

### `package.json`
- Added `"coverage": "vitest run --coverage"` script (`@vitest/coverage-v8` was already installed)

### `pr-hygiene.yml` — full rewrite
- Triggers: `[main]` only (removed `develop`)
- **Removed** `pr-hygiene-branch` job — was blocking all standard PRs to `main` by enforcing a `develop` branch that doesn't exist
- **Fixed** labels check: now validates against actual repo labels (`enhancement`, `bug`, `refactor`, `chore`, `design-system`) instead of `type:` prefixed labels
- **Fixed** docs check: now watches `src/` + `ROADMAP.md`/`README.md` instead of Go paths (`internal/scaffold/scaffold.go`, `src/templates/.claude/agents/`); downgraded to `core.warning` (not blocking)

### `dco.yml` — minor fix
- Triggers: `[main]` only
- Removed `develop` SHA-filtering logic (dead code since `develop` branch doesn't exist)

## Impact

Before this PR: every standard PR targeting `main` would fail `pr-hygiene-branch` and `pr-hygiene-labels`.
After this PR: hygiene checks work correctly for this repo's main-only workflow.

Closes #23