### PR TITLE
fix(ui): add ErrorBoundary component and wrap routes and feature panels

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,6 +2,9 @@ import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
 import { useState, useEffect, useRef, type ReactNode } from "react";
 import { Check, ChevronDown, Moon, Sun, Zap } from "lucide-react";
 import { SymbolSelector } from "@/ui/symbol-selector";
+import { toast, Toaster } from "sonner";
+import { ErrorBoundary } from "@/ui/error-boundary";
+import { Button } from "@/ui/button";
 
 type ThemeId = "soft" | "night-city" | "maelstrom" | "corpo-ice" | "netrunner";
 type ModeId = "dark" | "light" | "vibrant";
@@ -152,6 +155,18 @@ const MOCK_NAV = {
 
 function RootComponent() {
   return (
+    <ErrorBoundary
+      fallback={(error) => (
+        <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-8 bg-card">
+          <p className="text-base font-semibold text-destructive">Application Error</p>
+          <p className="text-sm text-muted-foreground">{error.message}</p>
+          <Button intent="secondary" size="sm" onClick={() => window.location.reload()}>
+            Reload page
+          </Button>
+        </div>
+      )}
+      onError={(error) => toast.error(error.message)}
+    >
     <div
       className="min-h-screen flex flex-col"
       style={{ backgroundColor: "var(--color-background)" }}
@@ -221,6 +236,8 @@ function RootComponent() {
       <main className="flex-1 min-h-0">
         <Outlet />
       </main>
+      <Toaster position="bottom-right" theme="system" richColors />
     </div>
+    </ErrorBoundary>
   );
 }

--- a/src/routes/bots.$botId.tsx
+++ b/src/routes/bots.$botId.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from '@tanstack/react-router'
+import { ErrorBoundary } from '@/ui/error-boundary'
 import { useState } from 'react'
 import { ArrowLeft, Pencil, X, Check, Play, Pause, Square } from 'lucide-react'
 import { LineChart, Line, ResponsiveContainer, Tooltip, XAxis, YAxis, ReferenceLine } from 'recharts'
@@ -58,6 +59,7 @@ function BotDetailPage() {
   }
 
   return (
+    <ErrorBoundary>
     <div className="h-full overflow-y-auto" style={{ backgroundColor: 'var(--color-background)' }}>
       <div className="p-6 space-y-6">
 
@@ -329,5 +331,6 @@ function BotDetailPage() {
 
       </div>
     </div>
+    </ErrorBoundary>
   )
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { ErrorBoundary } from "@/ui/error-boundary";
 
 // biome-ignore lint/suspicious/noExplicitAny: TanStack Router codegen pending
 export const Route = createFileRoute("/" as any)({
@@ -27,6 +28,7 @@ const STACK = [
 
 export default function LandingPage() {
   return (
+    <ErrorBoundary>
     <div className="w-full max-w-4xl mx-auto px-6 py-20 flex flex-col gap-16">
       {/* Hero */}
       <section className="flex flex-col gap-6">
@@ -149,5 +151,6 @@ export default function LandingPage() {
         </div>
       </section>
     </div>
+    </ErrorBoundary>
   );
 }

--- a/src/routes/portfolio.tsx
+++ b/src/routes/portfolio.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { ErrorBoundary } from "@/ui/error-boundary";
 import { BalanceDisplay } from "@/features/portfolio/balance-display";
 import { PositionCard } from "@/features/portfolio/position-card";
 
@@ -99,6 +100,7 @@ const mockTrades: TradeHistory[] = [
 
 function RouteComponent() {
   return (
+    <ErrorBoundary>
     <div className="w-full max-w-5xl mx-auto px-6 py-8 space-y-8">
       {/* Header */}
       <div className="flex items-center justify-between">
@@ -204,5 +206,6 @@ function RouteComponent() {
         </div>
       </div>
     </div>
+    </ErrorBoundary>
   );
 }

--- a/src/routes/symbol/$symbol.tsx
+++ b/src/routes/symbol/$symbol.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { ErrorBoundary } from "@/ui/error-boundary";
 
 import { TradingLayout } from "./-trading-layout";
 
@@ -8,5 +9,9 @@ export const Route = createFileRoute("/symbol/$symbol" as never)({
 
 function RouteComponent() {
   const { symbol } = Route.useParams();
-  return <TradingLayout symbol={symbol} />;
+  return (
+    <ErrorBoundary>
+      <TradingLayout symbol={symbol} />
+    </ErrorBoundary>
+  );
 }

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -9,6 +9,7 @@ import { OrderForm } from "@/features/order-entry/order-form";
 import { BotManagerPanel } from "@/features/bots/bot-manager-panel";
 import { MOCK_BOTS } from "@/features/bots/mock-bots";
 import type { BotInstance, BotStatus } from "@/features/bots/types";
+import { ErrorBoundary } from "@/ui/error-boundary";
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
@@ -265,6 +266,7 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
   const [activeTimeframe, setActiveTimeframe] = useState("15m");
 
   return (
+    <ErrorBoundary>
     <div className="w-full px-3 pb-3 flex flex-col gap-0">
       {/* ── Ticker header ───────────────────────────────── */}
       <div className="flex items-center gap-6 py-2 border-b border-border mb-2">
@@ -314,9 +316,11 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
         onLayoutChange={handleLayoutChange}
       >
         <div key="book">
+          <ErrorBoundary>
           <Panel title="Order Book">
             <OrderBook state={mockOrderBookState} />
           </Panel>
+          </ErrorBoundary>
         </div>
 
         <div key="chart">
@@ -353,14 +357,17 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
         </div>
 
         <div key="order">
+          <ErrorBoundary>
           <Panel title="Place Order">
             <div className="p-3">
               <OrderForm onSubmit={handleOrderSubmit} isLoading={orderSubmitting} />
             </div>
           </Panel>
+          </ErrorBoundary>
         </div>
 
         <div key="portfolio">
+          <ErrorBoundary>
           <Panel title="Portfolio">
             <div className="p-3 grid grid-cols-2 gap-x-4 gap-y-3">
               <div>
@@ -433,12 +440,15 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
               </Link>
             </div>
           </Panel>
+          </ErrorBoundary>
         </div>
 
         <div key="bots">
+          <ErrorBoundary>
           <Panel title="Bots">
             <BotManagerPanel bots={bots} onStatusChange={handleBotStatusChange} />
           </Panel>
+          </ErrorBoundary>
         </div>
 
         <div key="trades">
@@ -513,5 +523,6 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
         </div>
       </ResponsiveGridLayout>
     </div>
+    </ErrorBoundary>
   );
 }

--- a/src/ui/error-boundary.test.tsx
+++ b/src/ui/error-boundary.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ErrorBoundary } from "./error-boundary";
+
+// Suppress React's console.error noise during error boundary tests
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function Thrower({ shouldThrow = false }: { shouldThrow?: boolean }) {
+  if (shouldThrow) throw new Error("Test error");
+  return <div>Child content</div>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error", () => {
+    render(
+      <ErrorBoundary>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  it("shows default fallback when child throws", () => {
+    render(
+      <ErrorBoundary>
+        <Thrower shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("Test error")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("calls onError callback when child throws", () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary onError={onError}>
+        <Thrower shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ componentStack: expect.any(String) }),
+    );
+  });
+
+  it("renders custom fallback prop when provided", () => {
+    const customFallback = (error: Error) => <div>Custom: {error.message}</div>;
+    render(
+      <ErrorBoundary fallback={customFallback}>
+        <Thrower shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("Custom: Test error")).toBeInTheDocument();
+  });
+
+  it("reset button clears error state and re-renders children", async () => {
+    const user = userEvent.setup();
+
+    // Use a ref-like object so the test controls when to stop throwing.
+    // A plain counter breaks in React 19 because concurrent mode retries the
+    // failed render synchronously — incrementing the counter a second time
+    // before the error boundary can catch. A boolean flag stays `true` on
+    // every retry until the test explicitly flips it.
+    const throwState = { shouldThrow: true };
+
+    function ControlledChild() {
+      if (throwState.shouldThrow) throw new Error("Test error");
+      return <div>Recovered content</div>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <ControlledChild />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    // Allow the child to render successfully on the next attempt
+    throwState.shouldThrow = false;
+
+    const resetBtn = screen.getByRole("button", { name: /try again/i });
+    await user.click(resetBtn);
+
+    expect(screen.getByText("Recovered content")).toBeInTheDocument();
+  });
+});

--- a/src/ui/error-boundary.tsx
+++ b/src/ui/error-boundary.tsx
@@ -1,0 +1,56 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Button } from "@/ui/button";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: (error: Error, reset: () => void) => ReactNode;
+  onError?: (error: Error, info: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    const { children, fallback } = this.props;
+
+    if (error) {
+      if (fallback) {
+        return fallback(error, this.reset);
+      }
+
+      return (
+        <div className="flex flex-col items-center justify-center gap-4 p-8 rounded-md border border-border bg-card">
+          <p className="text-base font-semibold text-destructive">Something went wrong</p>
+          <p className="text-sm text-muted-foreground">{error.message}</p>
+          <Button intent="secondary" size="sm" onClick={this.reset}>
+            Try again
+          </Button>
+        </div>
+      );
+    }
+
+    return children;
+  }
+}
+
+export { ErrorBoundary };


### PR DESCRIPTION
## Summary

Fixes #18 — no error boundaries means any component throw causes a full app crash.

## Changes

- **`src/ui/error-boundary.tsx`** — Reusable `ErrorBoundary` React class component
  - Props: `children`, optional `fallback` render prop, optional `onError` callback
  - Default fallback uses DS tokens: `bg-card`, `text-destructive`, `text-muted-foreground`, `border-border`
  - Reset button re-mounts children after error
- **`src/routes/__root.tsx`** — Root-level boundary wraps entire app; `onError` fires `toast.error()`; fallback offers "Reload page"
- **Per-route boundaries** on `index`, `portfolio`, `bots.$botId`, `symbol/$symbol`, `-trading-layout`
- **Per-panel boundaries** in `-trading-layout` for Order Book, Order Entry, Portfolio, and Bots panels
- **`src/ui/error-boundary.test.tsx`** — 5 vitest tests; all passing (118/118 suite total)

## Spec AC Coverage

> No dedicated error boundary spec exists (gap noted). Implementation guided by:
> - `specs/architecture.spec.md` — `src/ui/` layer for reusable UI primitives
> - `specs/design-system.spec.md` — DS tokens enforced (no raw colors)
> - `specs/tech-stack.spec.md` — route-level error boundaries for TanStack Query integration

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | `ErrorBoundary` class component with DS-token fallback | ✅ |
| AC-2 | Root-level boundary with `toast.error` + reload fallback | ✅ |
| AC-3 | Per-route boundaries on all 5 routes | ✅ |
| AC-4 | Per-panel boundaries (order book, order entry, portfolio, bots) | ✅ |
| AC-5 | 5 tests: render, fallback, onError, custom fallback, reset | ✅ |

## Test Results

`pnpm build` ✅ — no TypeScript errors
`pnpm test` ✅ — 118/118 tests passing