### PR TITLE
fix(a11y): add aria-labels to icon buttons, wire input labels, add route titles

### DIFF
--- a/src/features/bots/bot-manager-panel.tsx
+++ b/src/features/bots/bot-manager-panel.tsx
@@ -141,6 +141,7 @@ export function BotManagerPanel({ bots, onStatusChange }: BotManagerPanelProps) 
                           <button
                             className="flex items-center justify-center w-6 h-6 rounded cursor-pointer text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                             title="Pause"
+                            aria-label="Pause bot"
                             onClick={() => onStatusChange(bot.id, "paused")}
                           >
                             <Pause size={11} />
@@ -149,6 +150,7 @@ export function BotManagerPanel({ bots, onStatusChange }: BotManagerPanelProps) 
                             className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
                             style={{ color: "var(--trading-ask)" }}
                             title="Stop"
+                            aria-label="Stop bot"
                             onClick={() => onStatusChange(bot.id, "stopped")}
                           >
                             <Square size={11} />
@@ -161,6 +163,7 @@ export function BotManagerPanel({ bots, onStatusChange }: BotManagerPanelProps) 
                             className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
                             style={{ color: "var(--trading-bid)" }}
                             title="Run"
+                            aria-label="Run bot"
                             onClick={() => onStatusChange(bot.id, "running")}
                           >
                             <Play size={11} />
@@ -169,6 +172,7 @@ export function BotManagerPanel({ bots, onStatusChange }: BotManagerPanelProps) 
                             className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
                             style={{ color: "var(--trading-ask)" }}
                             title="Stop"
+                            aria-label="Stop bot"
                             onClick={() => onStatusChange(bot.id, "stopped")}
                           >
                             <Square size={11} />
@@ -180,6 +184,7 @@ export function BotManagerPanel({ bots, onStatusChange }: BotManagerPanelProps) 
                           className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
                           style={{ color: "var(--trading-bid)" }}
                           title="Run"
+                          aria-label="Run bot"
                           onClick={() => onStatusChange(bot.id, "running")}
                         >
                           <Play size={11} />

--- a/src/lib/contrast.test.ts
+++ b/src/lib/contrast.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTRAST_PAIRS,
+  REQUIRED_RATIO,
+  contrastRatio,
+  meetsRequired,
+  oklchToLuminance,
+  parseOklch,
+  wcagLevel,
+} from "./contrast";
+
+describe("parseOklch", () => {
+  it("parses valid oklch string", () => {
+    expect(parseOklch("oklch(0.5 0.1 200)")).toEqual({ l: 0.5, c: 0.1, h: 200 });
+  });
+
+  it("parses oklch with alpha channel", () => {
+    const result = parseOklch("oklch(0.5 0.1 200 / 0.5)");
+    expect(result).toEqual({ l: 0.5, c: 0.1, h: 200 });
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseOklch("OKLCH(0.5 0.1 200)")).toEqual({ l: 0.5, c: 0.1, h: 200 });
+  });
+
+  it("returns null for non-oklch strings", () => {
+    expect(parseOklch("rgb(0,0,0)")).toBeNull();
+    expect(parseOklch("red")).toBeNull();
+    expect(parseOklch("")).toBeNull();
+  });
+
+  it("handles oklch(0 0 0)", () => {
+    expect(parseOklch("oklch(0 0 0)")).toEqual({ l: 0, c: 0, h: 0 });
+  });
+});
+
+describe("oklchToLuminance", () => {
+  it("black (0,0,0) returns approximately 0", () => {
+    expect(oklchToLuminance(0, 0, 0)).toBeCloseTo(0, 2);
+  });
+
+  it("white (1,0,0) returns approximately 1", () => {
+    expect(oklchToLuminance(1, 0, 0)).toBeCloseTo(1, 1);
+  });
+
+  it("mid-gray returns value between 0 and 1", () => {
+    const lum = oklchToLuminance(0.5, 0, 0);
+    expect(lum).toBeGreaterThan(0);
+    expect(lum).toBeLessThan(1);
+  });
+
+  it("output is always in [0,1] range", () => {
+    const testCases = [
+      [0, 0, 0],
+      [1, 0, 0],
+      [0.5, 0.1, 200],
+      [0.7, 0.15, 30],
+      [0.3, 0.05, 300],
+    ] as const;
+    for (const [l, c, h] of testCases) {
+      const lum = oklchToLuminance(l, c, h);
+      expect(lum).toBeGreaterThanOrEqual(0);
+      expect(lum).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("contrastRatio", () => {
+  it("identical luminances returns 1", () => {
+    expect(contrastRatio(0.5, 0.5)).toBe(1);
+  });
+
+  it("black vs white returns 21", () => {
+    expect(contrastRatio(0, 1)).toBe(21);
+  });
+
+  it("is order-independent", () => {
+    const a = 0.2;
+    const b = 0.8;
+    expect(contrastRatio(a, b)).toBe(contrastRatio(b, a));
+  });
+});
+
+describe("wcagLevel", () => {
+  it("returns AAA for ratio >= 7", () => {
+    expect(wcagLevel(10)).toBe("AAA");
+  });
+
+  it("returns AA for ratio in [4.5, 7)", () => {
+    expect(wcagLevel(5)).toBe("AA");
+  });
+
+  it("returns AA-Large for ratio in [3, 4.5)", () => {
+    expect(wcagLevel(3.5)).toBe("AA-Large");
+  });
+
+  it("returns FAIL for ratio < 3", () => {
+    expect(wcagLevel(2)).toBe("FAIL");
+  });
+
+  it("exact boundary: 7.0 → AAA", () => {
+    expect(wcagLevel(7.0)).toBe("AAA");
+  });
+
+  it("exact boundary: 4.5 → AA", () => {
+    expect(wcagLevel(4.5)).toBe("AA");
+  });
+
+  it("exact boundary: 3.0 → AA-Large", () => {
+    expect(wcagLevel(3.0)).toBe("AA-Large");
+  });
+});
+
+describe("meetsRequired", () => {
+  it("ratio meets AAA threshold", () => {
+    expect(meetsRequired(7, "AAA")).toBe(true);
+  });
+
+  it("ratio below AAA", () => {
+    expect(meetsRequired(6.9, "AAA")).toBe(false);
+  });
+
+  it("any ratio meets FAIL (threshold 0)", () => {
+    expect(meetsRequired(1, "FAIL")).toBe(true);
+  });
+
+  it("ratio meets AA", () => {
+    expect(meetsRequired(4.5, "AA")).toBe(true);
+  });
+});
+
+describe("REQUIRED_RATIO", () => {
+  it("has entries for all 4 WcagLevel values", () => {
+    expect(REQUIRED_RATIO).toHaveProperty("AAA");
+    expect(REQUIRED_RATIO).toHaveProperty("AA");
+    expect(REQUIRED_RATIO).toHaveProperty("AA-Large");
+    expect(REQUIRED_RATIO).toHaveProperty("FAIL");
+    expect(Object.keys(REQUIRED_RATIO)).toHaveLength(4);
+  });
+});
+
+describe("CONTRAST_PAIRS", () => {
+  it("has 13 entries", () => {
+    expect(CONTRAST_PAIRS).toHaveLength(13);
+  });
+
+  it("all pairs have name, fg, bg, required fields", () => {
+    for (const pair of CONTRAST_PAIRS) {
+      expect(pair).toHaveProperty("name");
+      expect(pair).toHaveProperty("fg");
+      expect(pair).toHaveProperty("bg");
+      expect(pair).toHaveProperty("required");
+      expect(typeof pair.name).toBe("string");
+      expect(typeof pair.fg).toBe("string");
+      expect(typeof pair.bg).toBe("string");
+      expect(["AAA", "AA", "AA-Large", "FAIL"]).toContain(pair.required);
+    }
+  });
+});

--- a/src/lib/symbols.test.ts
+++ b/src/lib/symbols.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SYMBOL, SYMBOL_CATEGORIES, SYMBOLS, findSymbol } from "./symbols";
+
+describe("SYMBOLS", () => {
+  it("has 18 entries", () => {
+    expect(SYMBOLS).toHaveLength(18);
+  });
+
+  it("every symbol has symbol, base, quote, category fields", () => {
+    for (const s of SYMBOLS) {
+      expect(typeof s.symbol).toBe("string");
+      expect(typeof s.base).toBe("string");
+      expect(typeof s.quote).toBe("string");
+      expect(typeof s.category).toBe("string");
+    }
+  });
+
+  it("no duplicate symbol strings", () => {
+    const symbols = SYMBOLS.map((s) => s.symbol);
+    expect(new Set(symbols).size).toBe(symbols.length);
+  });
+
+  it("all categories are valid SYMBOL_CATEGORIES values", () => {
+    for (const s of SYMBOLS) {
+      expect(SYMBOL_CATEGORIES).toContain(s.category);
+    }
+  });
+});
+
+describe("DEFAULT_SYMBOL", () => {
+  it('equals "BTCUSDT"', () => {
+    expect(DEFAULT_SYMBOL).toBe("BTCUSDT");
+  });
+
+  it("exists in SYMBOLS array", () => {
+    const found = SYMBOLS.find((s) => s.symbol === DEFAULT_SYMBOL);
+    expect(found).toBeDefined();
+  });
+});
+
+describe("findSymbol", () => {
+  it("returns SymbolInfo for existing symbol", () => {
+    const result = findSymbol("BTCUSDT");
+    expect(result).toBeDefined();
+    expect(result?.symbol).toBe("BTCUSDT");
+    expect(result?.base).toBe("BTC");
+    expect(result?.quote).toBe("USDT");
+  });
+
+  it("returns undefined for non-existent symbol", () => {
+    expect(findSymbol("DOESNOTEXIST")).toBeUndefined();
+  });
+
+  it("is case-sensitive", () => {
+    expect(findSymbol("btcusdt")).toBeUndefined();
+  });
+});
+
+describe("SYMBOL_CATEGORIES", () => {
+  it("has 4 entries", () => {
+    expect(SYMBOL_CATEGORIES).toHaveLength(4);
+  });
+
+  it("contains USDT, BTC, ETH, BNB", () => {
+    expect(SYMBOL_CATEGORIES).toContain("USDT");
+    expect(SYMBOL_CATEGORIES).toContain("BTC");
+    expect(SYMBOL_CATEGORIES).toContain("ETH");
+    expect(SYMBOL_CATEGORIES).toContain("BNB");
+  });
+});

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -115,6 +115,7 @@ function ThemeDropdown() {
                 key={m.id}
                 onClick={() => selectMode(m.id)}
                 title={m.label}
+                aria-label={m.label}
                 className="flex items-center justify-center flex-1 h-6 rounded cursor-pointer transition-colors"
                 style={{
                   backgroundColor: m.id === mode ? "var(--primary)" : "transparent",

--- a/src/routes/bots.$botId.tsx
+++ b/src/routes/bots.$botId.tsx
@@ -59,6 +59,7 @@ function BotDetailPage() {
 
   return (
     <div className="h-full overflow-y-auto" style={{ backgroundColor: 'var(--color-background)' }}>
+      <title>{bot ? `${bot.name} | Trading Engine` : 'Bot | Trading Engine'}</title>
       <div className="p-6 space-y-6">
 
         {/* Header */}
@@ -196,6 +197,7 @@ function BotDetailPage() {
                   onClick={startEdit}
                   className="flex items-center gap-1 w-6 h-6 rounded justify-center cursor-pointer text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                   title="Edit settings"
+                  aria-label="Edit settings"
                 >
                   <Pencil size={11} />
                 </button>
@@ -206,6 +208,7 @@ function BotDetailPage() {
                     className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:bg-muted transition-colors"
                     style={{ color: 'var(--trading-profit)' }}
                     title="Save"
+                    aria-label="Save settings"
                   >
                     <Check size={11} />
                   </button>
@@ -213,6 +216,7 @@ function BotDetailPage() {
                     onClick={() => setEditing(false)}
                     className="flex items-center justify-center w-6 h-6 rounded cursor-pointer text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                     title="Cancel"
+                    aria-label="Cancel edit"
                   >
                     <X size={11} />
                   </button>
@@ -223,10 +227,11 @@ function BotDetailPage() {
             <div className="space-y-3">
               {/* Name */}
               <div>
-                <label className="text-[10px] text-muted-foreground uppercase tracking-wide block mb-1">Name</label>
+                <label htmlFor="bot-name-input" className="text-[10px] text-muted-foreground uppercase tracking-wide block mb-1">Name</label>
                 {editing ? (
                   <input
-                    className="w-full rounded border border-border bg-card px-2 py-1 text-xs font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+                    id="bot-name-input"
+                    className="w-full rounded border border-border bg-card px-2 py-1 text-xs font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)]"
                     value={draft.name}
                     onChange={(e) => setDraft({ ...draft, name: e.target.value })}
                   />
@@ -237,10 +242,11 @@ function BotDetailPage() {
 
               {/* Strategy */}
               <div>
-                <label className="text-[10px] text-muted-foreground uppercase tracking-wide block mb-1">Strategy</label>
+                <label htmlFor="bot-strategy-select" className="text-[10px] text-muted-foreground uppercase tracking-wide block mb-1">Strategy</label>
                 {editing ? (
                   <select
-                    className="w-full rounded border border-border bg-card px-2 py-1 text-xs font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary cursor-pointer"
+                    id="bot-strategy-select"
+                    className="w-full rounded border border-border bg-card px-2 py-1 text-xs font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)] cursor-pointer"
                     value={draft.strategy}
                     onChange={(e) => setDraft({ ...draft, strategy: e.target.value as BotStrategy })}
                   >
@@ -255,10 +261,11 @@ function BotDetailPage() {
 
               {/* Symbol */}
               <div>
-                <label className="text-[10px] text-muted-foreground uppercase tracking-wide block mb-1">Symbol</label>
+                <label htmlFor="bot-symbol-input" className="text-[10px] text-muted-foreground uppercase tracking-wide block mb-1">Symbol</label>
                 {editing ? (
                   <input
-                    className="w-full rounded border border-border bg-card px-2 py-1 text-xs font-mono focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary"
+                    id="bot-symbol-input"
+                    className="w-full rounded border border-border bg-card px-2 py-1 text-xs font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)]"
                     value={draft.symbol}
                     onChange={(e) => setDraft({ ...draft, symbol: e.target.value.toUpperCase() })}
                   />

--- a/src/routes/design-system.lazy.tsx
+++ b/src/routes/design-system.lazy.tsx
@@ -230,6 +230,7 @@ function DesignSystemShowcase() {
 
   return (
     <div className="min-h-screen bg-background text-foreground">
+      <title>Design System | Trading Engine</title>
       <div className="max-w-7xl mx-auto px-6 py-12 space-y-16">
         {/* Header */}
         <div className="space-y-4">
@@ -468,9 +469,9 @@ function DesignSystemShowcase() {
         {/* ── Input ───────────────────────────────────────── */}
         <Section title="Input">
           <div className="max-w-xs space-y-2">
-            <Input placeholder="Price (USDT)" type="number" />
-            <Input placeholder="Quantity (BTC)" type="number" />
-            <Input placeholder="Disabled" disabled />
+            <Input placeholder="Price (USDT)" type="number" aria-label="Price in USDT" />
+            <Input placeholder="Quantity (BTC)" type="number" aria-label="Quantity in BTC" />
+            <Input placeholder="Disabled" disabled aria-label="Disabled input example" />
           </div>
         </Section>
 
@@ -678,12 +679,12 @@ function DesignSystemShowcase() {
             </div>
             <div className="space-y-2">
               <div className="space-y-1">
-                <p className="text-[10px] font-mono text-muted-foreground">Price (USDT)</p>
-                <Input placeholder="67,843.50" type="number" className="h-8 text-sm" />
+                <label htmlFor="ds-price-input" className="text-[10px] font-mono text-muted-foreground">Price (USDT)</label>
+                <Input id="ds-price-input" placeholder="67,843.50" type="number" className="h-8 text-sm" />
               </div>
               <div className="space-y-1">
-                <p className="text-[10px] font-mono text-muted-foreground">Amount (BTC)</p>
-                <Input placeholder="0.001" type="number" className="h-8 text-sm" />
+                <label htmlFor="ds-amount-input" className="text-[10px] font-mono text-muted-foreground">Amount (BTC)</label>
+                <Input id="ds-amount-input" placeholder="0.001" type="number" className="h-8 text-sm" />
               </div>
             </div>
             <div className="flex justify-between text-[10px] font-mono text-muted-foreground">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -28,6 +28,7 @@ const STACK = [
 export default function LandingPage() {
   return (
     <div className="w-full max-w-4xl mx-auto px-6 py-20 flex flex-col gap-16">
+      <title>Home | Trading Engine</title>
       {/* Hero */}
       <section className="flex flex-col gap-6">
         <div className="flex items-center gap-3">

--- a/src/routes/portfolio.tsx
+++ b/src/routes/portfolio.tsx
@@ -100,6 +100,7 @@ const mockTrades: TradeHistory[] = [
 function RouteComponent() {
   return (
     <div className="w-full max-w-5xl mx-auto px-6 py-8 space-y-8">
+      <title>Portfolio | Trading Engine</title>
       {/* Header */}
       <div className="flex items-center justify-between">
         <h1

--- a/src/routes/symbol/$symbol.tsx
+++ b/src/routes/symbol/$symbol.tsx
@@ -8,5 +8,10 @@ export const Route = createFileRoute("/symbol/$symbol" as never)({
 
 function RouteComponent() {
   const { symbol } = Route.useParams();
-  return <TradingLayout symbol={symbol} />;
+  return (
+    <>
+      <title>{symbol} | Trading Engine</title>
+      <TradingLayout symbol={symbol} />
+    </>
+  );
 }

--- a/src/ui/badge.test.tsx
+++ b/src/ui/badge.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Badge } from "./badge";
+
+describe("Badge", () => {
+  it("renders children text", () => {
+    render(<Badge>Hello</Badge>);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("renders as a span element", () => {
+    render(<Badge>Tag</Badge>);
+    const el = screen.getByText("Tag");
+    expect(el.tagName).toBe("SPAN");
+  });
+
+  it("applies default variant (pill) classes when no variant specified", () => {
+    render(<Badge>Default</Badge>);
+    const el = screen.getByText("Default");
+    expect(el).toHaveClass("bg-ds-gray-800", "text-muted-foreground");
+  });
+
+  it("applies active variant classes", () => {
+    render(<Badge variant="active">Active</Badge>);
+    const el = screen.getByText("Active");
+    expect(el).toHaveClass("text-primary", "border");
+  });
+
+  it("applies muted variant classes", () => {
+    render(<Badge variant="muted">Muted</Badge>);
+    const el = screen.getByText("Muted");
+    expect(el).toHaveClass("text-muted-foreground", "border");
+  });
+
+  it("applies buy variant classes", () => {
+    render(<Badge variant="buy">Buy</Badge>);
+    const el = screen.getByText("Buy");
+    expect(el).toHaveClass("border");
+  });
+
+  it("applies sell variant classes", () => {
+    render(<Badge variant="sell">Sell</Badge>);
+    const el = screen.getByText("Sell");
+    expect(el).toHaveClass("border");
+  });
+
+  it("applies filled variant classes", () => {
+    render(<Badge variant="filled">Filled</Badge>);
+    const el = screen.getByText("Filled");
+    expect(el).toHaveClass("border");
+  });
+
+  it("applies cancelled variant classes", () => {
+    render(<Badge variant="cancelled">Cancelled</Badge>);
+    const el = screen.getByText("Cancelled");
+    expect(el).toHaveClass("text-muted-foreground", "border");
+  });
+
+  it("applies open variant classes", () => {
+    render(<Badge variant="open">Open</Badge>);
+    const el = screen.getByText("Open");
+    expect(el).toHaveClass("text-primary", "border");
+  });
+
+  it("applies stat variant classes (different sizing: text-xs)", () => {
+    render(<Badge variant="stat">123</Badge>);
+    const el = screen.getByText("123");
+    expect(el).toHaveClass("text-xs", "bg-ds-gray-800", "px-2", "py-1");
+  });
+
+  it("merges custom className with variant classes", () => {
+    render(<Badge className="custom-extra">Custom</Badge>);
+    const el = screen.getByText("Custom");
+    expect(el).toHaveClass("custom-extra");
+    // Still has base classes
+    expect(el).toHaveClass("inline-flex", "items-center");
+  });
+
+  it("forwards HTML attributes like data-testid", () => {
+    render(<Badge data-testid="my-badge">Test</Badge>);
+    expect(screen.getByTestId("my-badge")).toBeInTheDocument();
+  });
+});

--- a/src/ui/symbol-selector.test.tsx
+++ b/src/ui/symbol-selector.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+const mockNavigate = vi.fn();
+let mockPathname = "/symbol/BTCUSDT";
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+  useRouterState: ({ select }: { select: (state: unknown) => unknown }) =>
+    select({ location: { pathname: mockPathname } }),
+}));
+
+import { SymbolSelector } from "./symbol-selector";
+
+describe("SymbolSelector", () => {
+  it("renders button with current symbol from URL", () => {
+    render(<SymbolSelector />);
+    expect(screen.getByText("BTCUSDT")).toBeInTheDocument();
+  });
+
+  it("hides dropdown initially", () => {
+    render(<SymbolSelector />);
+    expect(screen.queryByPlaceholderText("Search pair...")).not.toBeInTheDocument();
+  });
+
+  it("shows dropdown when button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    expect(screen.getByPlaceholderText("Search pair...")).toBeInTheDocument();
+  });
+
+  it("shows category headers when dropdown is open with no search", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    expect(screen.getByText("USDT pairs")).toBeInTheDocument();
+    expect(screen.getByText("BTC pairs")).toBeInTheDocument();
+    expect(screen.getByText("ETH pairs")).toBeInTheDocument();
+  });
+
+  it("filters symbols by search text (case-insensitive)", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    await user.type(screen.getByPlaceholderText("Search pair..."), "sol");
+    // SOL symbols should appear (multiple: SOLUSDT, SOLBTC, SOLETH)
+    const solElements = screen.getAllByText("SOL");
+    expect(solElements.length).toBeGreaterThanOrEqual(1);
+    // BNB-only symbols should not appear
+    expect(screen.queryByText("ADA")).not.toBeInTheDocument();
+  });
+
+  it('shows "No results" when search matches nothing', async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    await user.type(screen.getByPlaceholderText("Search pair..."), "zzzzz");
+    expect(screen.getByText("No results")).toBeInTheDocument();
+  });
+
+  it("calls navigate on symbol selection", async () => {
+    const user = userEvent.setup();
+    mockNavigate.mockClear();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    // Click on ETHUSDT row — find the "ETH" text within the list (not the category header)
+    const ethButtons = screen.getAllByRole("button", { name: /ETH/ });
+    // The first button is the selector trigger, find the list buttons
+    const listButton = ethButtons.find(
+      (btn) => btn.textContent?.includes("/USDT"),
+    );
+    expect(listButton).toBeDefined();
+    await user.click(listButton!);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ symbol: "ETHUSDT" }),
+      }),
+    );
+  });
+
+  it("closes dropdown after symbol selection", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    expect(screen.getByPlaceholderText("Search pair...")).toBeInTheDocument();
+    const ethButtons = screen.getAllByRole("button", { name: /ETH/ });
+    const listButton = ethButtons.find(
+      (btn) => btn.textContent?.includes("/USDT"),
+    );
+    await user.click(listButton!);
+    expect(screen.queryByPlaceholderText("Search pair...")).not.toBeInTheDocument();
+  });
+
+  it("closes dropdown on Escape key", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    expect(screen.getByPlaceholderText("Search pair...")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByPlaceholderText("Search pair...")).not.toBeInTheDocument();
+  });
+});
+
+describe("SymbolSelector with no symbol in URL", () => {
+  it('renders with "SELECT PAIR" when no symbol in URL', () => {
+    mockPathname = "/other-page";
+    render(<SymbolSelector />);
+    expect(screen.getByText("SELECT PAIR")).toBeInTheDocument();
+    mockPathname = "/symbol/BTCUSDT";
+  });
+});

--- a/src/ui/symbol-selector.tsx
+++ b/src/ui/symbol-selector.tsx
@@ -77,6 +77,7 @@ export function SymbolSelector() {
               ref={searchRef}
               type="text"
               placeholder="Search pair..."
+              aria-label="Search trading pair"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="w-full bg-transparent text-foreground placeholder:text-muted-foreground text-xs font-mono focus-visible:outline-none"


### PR DESCRIPTION
## Summary

Fixes all accessibility gaps identified in #19.

### Changes
- **Icon-only buttons (9 fixed):** Added `aria-label` to mode-switcher buttons in root layout, bot control buttons (Pause/Stop/Play), and bot-detail edit panel (Pencil/Check/X)
- **Input labels (6 fixed):** Wired `<label htmlFor>`+`id` pairs for bot settings Name, Strategy, Symbol fields; added `aria-label` to SymbolSelector search input and Design System showcase inputs; converted `<p>` pseudo-labels to proper `<label>` elements in Design System Order Entry
- **Route titles (5 added):** Added `<title>Page | Trading Engine</title>` to index, portfolio, bots detail (dynamic with bot name), design-system, and symbol/trading pages using React 19 JSX title hoisting
- **focus-visible fix (3 fixed):** Replaced `focus-visible:ring-1 focus-visible:ring-primary` with approved `focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)]` pattern in `bots.$botId.tsx`

### Spec note
No dedicated a11y spec exists in `specs/`. These fixes address WCAG 2.1 AA requirements for accessible names (SC 4.1.2), page titles (SC 2.4.2), and focus visibility (SC 2.4.7). A spec should be created to track a11y acceptance criteria going forward.

### Verification
- `pnpm build` ✅ passes
- `pnpm test` ✅ 117 tests pass, 1 skipped

Closes #19