### PR TITLE
test(coverage): add tests for badge, symbol-selector, contrast, and symbols

### DIFF
--- a/src/lib/contrast.test.ts
+++ b/src/lib/contrast.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  CONTRAST_PAIRS,
+  REQUIRED_RATIO,
+  contrastRatio,
+  meetsRequired,
+  oklchToLuminance,
+  parseOklch,
+  wcagLevel,
+} from "./contrast";
+
+describe("parseOklch", () => {
+  it("parses valid oklch string", () => {
+    expect(parseOklch("oklch(0.5 0.1 200)")).toEqual({ l: 0.5, c: 0.1, h: 200 });
+  });
+
+  it("parses oklch with alpha channel", () => {
+    const result = parseOklch("oklch(0.5 0.1 200 / 0.5)");
+    expect(result).toEqual({ l: 0.5, c: 0.1, h: 200 });
+  });
+
+  it("is case-insensitive", () => {
+    expect(parseOklch("OKLCH(0.5 0.1 200)")).toEqual({ l: 0.5, c: 0.1, h: 200 });
+  });
+
+  it("returns null for non-oklch strings", () => {
+    expect(parseOklch("rgb(0,0,0)")).toBeNull();
+    expect(parseOklch("red")).toBeNull();
+    expect(parseOklch("")).toBeNull();
+  });
+
+  it("handles oklch(0 0 0)", () => {
+    expect(parseOklch("oklch(0 0 0)")).toEqual({ l: 0, c: 0, h: 0 });
+  });
+});
+
+describe("oklchToLuminance", () => {
+  it("black (0,0,0) returns approximately 0", () => {
+    expect(oklchToLuminance(0, 0, 0)).toBeCloseTo(0, 2);
+  });
+
+  it("white (1,0,0) returns approximately 1", () => {
+    expect(oklchToLuminance(1, 0, 0)).toBeCloseTo(1, 1);
+  });
+
+  it("mid-gray returns value between 0 and 1", () => {
+    const lum = oklchToLuminance(0.5, 0, 0);
+    expect(lum).toBeGreaterThan(0);
+    expect(lum).toBeLessThan(1);
+  });
+
+  it("output is always in [0,1] range", () => {
+    const testCases = [
+      [0, 0, 0],
+      [1, 0, 0],
+      [0.5, 0.1, 200],
+      [0.7, 0.15, 30],
+      [0.3, 0.05, 300],
+    ] as const;
+    for (const [l, c, h] of testCases) {
+      const lum = oklchToLuminance(l, c, h);
+      expect(lum).toBeGreaterThanOrEqual(0);
+      expect(lum).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("contrastRatio", () => {
+  it("identical luminances returns 1", () => {
+    expect(contrastRatio(0.5, 0.5)).toBe(1);
+  });
+
+  it("black vs white returns 21", () => {
+    expect(contrastRatio(0, 1)).toBe(21);
+  });
+
+  it("is order-independent", () => {
+    const a = 0.2;
+    const b = 0.8;
+    expect(contrastRatio(a, b)).toBe(contrastRatio(b, a));
+  });
+});
+
+describe("wcagLevel", () => {
+  it("returns AAA for ratio >= 7", () => {
+    expect(wcagLevel(10)).toBe("AAA");
+  });
+
+  it("returns AA for ratio in [4.5, 7)", () => {
+    expect(wcagLevel(5)).toBe("AA");
+  });
+
+  it("returns AA-Large for ratio in [3, 4.5)", () => {
+    expect(wcagLevel(3.5)).toBe("AA-Large");
+  });
+
+  it("returns FAIL for ratio < 3", () => {
+    expect(wcagLevel(2)).toBe("FAIL");
+  });
+
+  it("exact boundary: 7.0 → AAA", () => {
+    expect(wcagLevel(7.0)).toBe("AAA");
+  });
+
+  it("exact boundary: 4.5 → AA", () => {
+    expect(wcagLevel(4.5)).toBe("AA");
+  });
+
+  it("exact boundary: 3.0 → AA-Large", () => {
+    expect(wcagLevel(3.0)).toBe("AA-Large");
+  });
+});
+
+describe("meetsRequired", () => {
+  it("ratio meets AAA threshold", () => {
+    expect(meetsRequired(7, "AAA")).toBe(true);
+  });
+
+  it("ratio below AAA", () => {
+    expect(meetsRequired(6.9, "AAA")).toBe(false);
+  });
+
+  it("any ratio meets FAIL (threshold 0)", () => {
+    expect(meetsRequired(1, "FAIL")).toBe(true);
+  });
+
+  it("ratio meets AA", () => {
+    expect(meetsRequired(4.5, "AA")).toBe(true);
+  });
+});
+
+describe("REQUIRED_RATIO", () => {
+  it("has entries for all 4 WcagLevel values", () => {
+    expect(REQUIRED_RATIO).toHaveProperty("AAA");
+    expect(REQUIRED_RATIO).toHaveProperty("AA");
+    expect(REQUIRED_RATIO).toHaveProperty("AA-Large");
+    expect(REQUIRED_RATIO).toHaveProperty("FAIL");
+    expect(Object.keys(REQUIRED_RATIO)).toHaveLength(4);
+  });
+});
+
+describe("CONTRAST_PAIRS", () => {
+  it("has 13 entries", () => {
+    expect(CONTRAST_PAIRS).toHaveLength(13);
+  });
+
+  it("all pairs have name, fg, bg, required fields", () => {
+    for (const pair of CONTRAST_PAIRS) {
+      expect(pair).toHaveProperty("name");
+      expect(pair).toHaveProperty("fg");
+      expect(pair).toHaveProperty("bg");
+      expect(pair).toHaveProperty("required");
+      expect(typeof pair.name).toBe("string");
+      expect(typeof pair.fg).toBe("string");
+      expect(typeof pair.bg).toBe("string");
+      expect(["AAA", "AA", "AA-Large", "FAIL"]).toContain(pair.required);
+    }
+  });
+});

--- a/src/lib/symbols.test.ts
+++ b/src/lib/symbols.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SYMBOL, SYMBOL_CATEGORIES, SYMBOLS, findSymbol } from "./symbols";
+
+describe("SYMBOLS", () => {
+  it("has 18 entries", () => {
+    expect(SYMBOLS).toHaveLength(18);
+  });
+
+  it("every symbol has symbol, base, quote, category fields", () => {
+    for (const s of SYMBOLS) {
+      expect(typeof s.symbol).toBe("string");
+      expect(typeof s.base).toBe("string");
+      expect(typeof s.quote).toBe("string");
+      expect(typeof s.category).toBe("string");
+    }
+  });
+
+  it("no duplicate symbol strings", () => {
+    const symbols = SYMBOLS.map((s) => s.symbol);
+    expect(new Set(symbols).size).toBe(symbols.length);
+  });
+
+  it("all categories are valid SYMBOL_CATEGORIES values", () => {
+    for (const s of SYMBOLS) {
+      expect(SYMBOL_CATEGORIES).toContain(s.category);
+    }
+  });
+});
+
+describe("DEFAULT_SYMBOL", () => {
+  it('equals "BTCUSDT"', () => {
+    expect(DEFAULT_SYMBOL).toBe("BTCUSDT");
+  });
+
+  it("exists in SYMBOLS array", () => {
+    const found = SYMBOLS.find((s) => s.symbol === DEFAULT_SYMBOL);
+    expect(found).toBeDefined();
+  });
+});
+
+describe("findSymbol", () => {
+  it("returns SymbolInfo for existing symbol", () => {
+    const result = findSymbol("BTCUSDT");
+    expect(result).toBeDefined();
+    expect(result?.symbol).toBe("BTCUSDT");
+    expect(result?.base).toBe("BTC");
+    expect(result?.quote).toBe("USDT");
+  });
+
+  it("returns undefined for non-existent symbol", () => {
+    expect(findSymbol("DOESNOTEXIST")).toBeUndefined();
+  });
+
+  it("is case-sensitive", () => {
+    expect(findSymbol("btcusdt")).toBeUndefined();
+  });
+});
+
+describe("SYMBOL_CATEGORIES", () => {
+  it("has 4 entries", () => {
+    expect(SYMBOL_CATEGORIES).toHaveLength(4);
+  });
+
+  it("contains USDT, BTC, ETH, BNB", () => {
+    expect(SYMBOL_CATEGORIES).toContain("USDT");
+    expect(SYMBOL_CATEGORIES).toContain("BTC");
+    expect(SYMBOL_CATEGORIES).toContain("ETH");
+    expect(SYMBOL_CATEGORIES).toContain("BNB");
+  });
+});

--- a/src/ui/badge.test.tsx
+++ b/src/ui/badge.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Badge } from "./badge";
+
+describe("Badge", () => {
+  it("renders children text", () => {
+    render(<Badge>Hello</Badge>);
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("renders as a span element", () => {
+    render(<Badge>Tag</Badge>);
+    const el = screen.getByText("Tag");
+    expect(el.tagName).toBe("SPAN");
+  });
+
+  it("applies default variant (pill) classes when no variant specified", () => {
+    render(<Badge>Default</Badge>);
+    const el = screen.getByText("Default");
+    expect(el).toHaveClass("bg-ds-gray-800", "text-muted-foreground");
+  });
+
+  it("applies active variant classes", () => {
+    render(<Badge variant="active">Active</Badge>);
+    const el = screen.getByText("Active");
+    expect(el).toHaveClass("text-primary", "border");
+  });
+
+  it("applies muted variant classes", () => {
+    render(<Badge variant="muted">Muted</Badge>);
+    const el = screen.getByText("Muted");
+    expect(el).toHaveClass("text-muted-foreground", "border");
+  });
+
+  it("applies buy variant classes", () => {
+    render(<Badge variant="buy">Buy</Badge>);
+    const el = screen.getByText("Buy");
+    expect(el).toHaveClass("border");
+  });
+
+  it("applies sell variant classes", () => {
+    render(<Badge variant="sell">Sell</Badge>);
+    const el = screen.getByText("Sell");
+    expect(el).toHaveClass("border");
+  });
+
+  it("applies filled variant classes", () => {
+    render(<Badge variant="filled">Filled</Badge>);
+    const el = screen.getByText("Filled");
+    expect(el).toHaveClass("border");
+  });
+
+  it("applies cancelled variant classes", () => {
+    render(<Badge variant="cancelled">Cancelled</Badge>);
+    const el = screen.getByText("Cancelled");
+    expect(el).toHaveClass("text-muted-foreground", "border");
+  });
+
+  it("applies open variant classes", () => {
+    render(<Badge variant="open">Open</Badge>);
+    const el = screen.getByText("Open");
+    expect(el).toHaveClass("text-primary", "border");
+  });
+
+  it("applies stat variant classes (different sizing: text-xs)", () => {
+    render(<Badge variant="stat">123</Badge>);
+    const el = screen.getByText("123");
+    expect(el).toHaveClass("text-xs", "bg-ds-gray-800", "px-2", "py-1");
+  });
+
+  it("merges custom className with variant classes", () => {
+    render(<Badge className="custom-extra">Custom</Badge>);
+    const el = screen.getByText("Custom");
+    expect(el).toHaveClass("custom-extra");
+    // Still has base classes
+    expect(el).toHaveClass("inline-flex", "items-center");
+  });
+
+  it("forwards HTML attributes like data-testid", () => {
+    render(<Badge data-testid="my-badge">Test</Badge>);
+    expect(screen.getByTestId("my-badge")).toBeInTheDocument();
+  });
+});

--- a/src/ui/symbol-selector.test.tsx
+++ b/src/ui/symbol-selector.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+const mockNavigate = vi.fn();
+let mockPathname = "/symbol/BTCUSDT";
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => mockNavigate,
+  useRouterState: ({ select }: { select: (state: unknown) => unknown }) =>
+    select({ location: { pathname: mockPathname } }),
+}));
+
+import { SymbolSelector } from "./symbol-selector";
+
+describe("SymbolSelector", () => {
+  it("renders button with current symbol from URL", () => {
+    render(<SymbolSelector />);
+    expect(screen.getByText("BTCUSDT")).toBeInTheDocument();
+  });
+
+  it("hides dropdown initially", () => {
+    render(<SymbolSelector />);
+    expect(screen.queryByPlaceholderText("Search pair...")).not.toBeInTheDocument();
+  });
+
+  it("shows dropdown when button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    expect(screen.getByPlaceholderText("Search pair...")).toBeInTheDocument();
+  });
+
+  it("shows category headers when dropdown is open with no search", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    expect(screen.getByText("USDT pairs")).toBeInTheDocument();
+    expect(screen.getByText("BTC pairs")).toBeInTheDocument();
+    expect(screen.getByText("ETH pairs")).toBeInTheDocument();
+  });
+
+  it("filters symbols by search text (case-insensitive)", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    await user.type(screen.getByPlaceholderText("Search pair..."), "sol");
+    // SOL symbols should appear (multiple: SOLUSDT, SOLBTC, SOLETH)
+    const solElements = screen.getAllByText("SOL");
+    expect(solElements.length).toBeGreaterThanOrEqual(1);
+    // BNB-only symbols should not appear
+    expect(screen.queryByText("ADA")).not.toBeInTheDocument();
+  });
+
+  it('shows "No results" when search matches nothing', async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    await user.type(screen.getByPlaceholderText("Search pair..."), "zzzzz");
+    expect(screen.getByText("No results")).toBeInTheDocument();
+  });
+
+  it("calls navigate on symbol selection", async () => {
+    const user = userEvent.setup();
+    mockNavigate.mockClear();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    // Click on ETHUSDT row — find the "ETH" text within the list (not the category header)
+    const ethButtons = screen.getAllByRole("button", { name: /ETH/ });
+    // The first button is the selector trigger, find the list buttons
+    const listButton = ethButtons.find(
+      (btn) => btn.textContent?.includes("/USDT"),
+    );
+    expect(listButton).toBeDefined();
+    await user.click(listButton!);
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ symbol: "ETHUSDT" }),
+      }),
+    );
+  });
+
+  it("closes dropdown after symbol selection", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    expect(screen.getByPlaceholderText("Search pair...")).toBeInTheDocument();
+    const ethButtons = screen.getAllByRole("button", { name: /ETH/ });
+    const listButton = ethButtons.find(
+      (btn) => btn.textContent?.includes("/USDT"),
+    );
+    await user.click(listButton!);
+    expect(screen.queryByPlaceholderText("Search pair...")).not.toBeInTheDocument();
+  });
+
+  it("closes dropdown on Escape key", async () => {
+    const user = userEvent.setup();
+    render(<SymbolSelector />);
+    await user.click(screen.getByRole("button", { name: /BTCUSDT/ }));
+    expect(screen.getByPlaceholderText("Search pair...")).toBeInTheDocument();
+    await user.keyboard("{Escape}");
+    expect(screen.queryByPlaceholderText("Search pair...")).not.toBeInTheDocument();
+  });
+});
+
+describe("SymbolSelector with no symbol in URL", () => {
+  it('renders with "SELECT PAIR" when no symbol in URL', () => {
+    mockPathname = "/other-page";
+    render(<SymbolSelector />);
+    expect(screen.getByText("SELECT PAIR")).toBeInTheDocument();
+    mockPathname = "/symbol/BTCUSDT";
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5

Adds **4 new test files** covering **60 new tests** for previously untested modules: badge, symbol-selector, contrast utilities, and symbol helpers.

## Files Added

- `src/lib/contrast.test.ts` — 26 tests for contrast utility functions
- `src/lib/symbols.test.ts` — 11 tests for symbol helper functions
- `src/ui/badge.test.tsx` — 13 tests for the Badge UI component
- `src/ui/symbol-selector.test.tsx` — 10 tests for the SymbolSelector UI component

## Test Results

✅ **180 tests passed** across 19 test files — **0 failures**

## Notes

- No source files were modified; this PR adds test coverage only.
- No docs update required (test-only change with no new UX surface).