### PR TITLE
fix(ui): reduce button font-weight for better dark theme readability

### DIFF
--- a/src/ui/button.test.tsx
+++ b/src/ui/button.test.tsx
@@ -70,4 +70,22 @@ describe("Button", () => {
     render(<Button ref={ref}>Ref</Button>);
     expect(ref.current).toBeInstanceOf(HTMLButtonElement);
   });
+
+  it("applies font-normal on base variant", () => {
+    render(<Button>Base</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveClass("font-normal");
+  });
+
+  it("applies font-medium on buy variant", () => {
+    render(<Button intent="buy">Buy</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveClass("font-medium");
+  });
+
+  it("applies font-medium on sell variant", () => {
+    render(<Button intent="sell">Sell</Button>);
+    const btn = screen.getByRole("button");
+    expect(btn).toHaveClass("font-medium");
+  });
 });

--- a/src/ui/button.tsx
+++ b/src/ui/button.tsx
@@ -2,15 +2,15 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)] disabled:opacity-50 disabled:cursor-not-allowed",
+  "inline-flex items-center justify-center rounded-md font-normal transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)] disabled:opacity-50 disabled:cursor-not-allowed",
   {
     variants: {
       intent: {
         primary: "bg-primary text-primary-foreground hover:bg-primary/90",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/90",
         danger: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        buy: "bg-[color:var(--trading-bid)] text-foreground font-semibold hover:opacity-90",
-        sell: "bg-[color:var(--trading-ask)] text-foreground font-semibold hover:opacity-90",
+        buy: "bg-[color:var(--trading-bid)] text-foreground font-medium hover:opacity-90",
+        sell: "bg-[color:var(--trading-ask)] text-foreground font-medium hover:opacity-90",
         ghost: "bg-transparent text-foreground hover:bg-muted",
       },
       size: {


### PR DESCRIPTION
## Summary

Reduce button font-weight across all variants for better readability on dark theme.

### Changes

| Location | Before | After |
|----------|--------|-------|
| Base cva class | `font-medium` (500) | `font-normal` (400) |
| Buy variant | `font-semibold` (600) | `font-medium` (500) |
| Sell variant | `font-semibold` (600) | `font-medium` (500) |

### Spec Coverage

- **AC-7** (design-system.spec.md): ✅ Base variant `font-normal`, buy/sell `font-medium`, zero `font-semibold` on any button
- 3 new test cases guard against regression

### Testing

- `pnpm build` ✅
- `pnpm test` ✅ (120 passed, 1 skipped)

Closes #11