### PR TITLE
feat(chart): replace div-based chart with lightweight-charts candlestick series

### DIFF
--- a/src/features/chart/candle-chart.tsx
+++ b/src/features/chart/candle-chart.tsx
@@ -1,0 +1,80 @@
+import {
+  createChart,
+  CandlestickSeries,
+  ColorType,
+  type CandlestickData,
+  type Time,
+} from "lightweight-charts";
+
+const MOCK_CANDLES: CandlestickData<Time>[] = [
+  { time: "2024-01-01" as Time, open: 67120, high: 67480, low: 67050, close: 67390 },
+  { time: "2024-01-02" as Time, open: 67390, high: 67620, low: 67300, close: 67580 },
+  { time: "2024-01-03" as Time, open: 67580, high: 67710, low: 67520, close: 67490 },
+  { time: "2024-01-04" as Time, open: 67490, high: 67550, low: 67320, close: 67350 },
+  { time: "2024-01-05" as Time, open: 67350, high: 67400, low: 67180, close: 67220 },
+  { time: "2024-01-06" as Time, open: 67220, high: 67680, low: 67200, close: 67650 },
+  { time: "2024-01-07" as Time, open: 67650, high: 67820, low: 67610, close: 67780 },
+  { time: "2024-01-08" as Time, open: 67780, high: 67900, low: 67730, close: 67860 },
+  { time: "2024-01-09" as Time, open: 67860, high: 67940, low: 67800, close: 67844 },
+];
+
+function cssVar(container: HTMLElement, name: string): string {
+  return getComputedStyle(container).getPropertyValue(name).trim();
+}
+
+export function CandleChart() {
+  const chartRef = (el: HTMLDivElement | null) => {
+    if (!el) return;
+
+    const textColor = cssVar(el, "--muted-foreground");
+    const borderColor = cssVar(el, "--border");
+
+    const chart = createChart(el, {
+      layout: {
+        background: { type: ColorType.Solid, color: "transparent" },
+        textColor,
+        fontFamily: "'Share Tech Mono', monospace",
+        fontSize: 10,
+      },
+      grid: {
+        vertLines: { color: borderColor },
+        horzLines: { color: borderColor },
+      },
+      crosshair: { mode: 0 },
+      rightPriceScale: {
+        borderColor,
+      },
+      timeScale: {
+        borderColor,
+        timeVisible: true,
+        secondsVisible: false,
+      },
+    });
+
+    const series = chart.addSeries(CandlestickSeries, {
+      upColor: cssVar(el, "--trading-bid"),
+      downColor: cssVar(el, "--trading-ask"),
+      wickUpColor: cssVar(el, "--trading-tick-up"),
+      wickDownColor: cssVar(el, "--trading-tick-down"),
+      borderVisible: false,
+    });
+
+    series.setData(MOCK_CANDLES);
+    chart.timeScale().fitContent();
+
+    const ro = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        chart.resize(width, height);
+      }
+    });
+    ro.observe(el);
+
+    return () => {
+      ro.disconnect();
+      chart.remove();
+    };
+  };
+
+  return <div ref={chartRef} className="w-full h-full" />;
+}

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -10,6 +10,7 @@ import { BotManagerPanel } from "@/features/bots/bot-manager-panel";
 import { MOCK_BOTS } from "@/features/bots/mock-bots";
 import type { BotInstance, BotStatus } from "@/features/bots/types";
 import { ErrorBoundary } from "@/ui/error-boundary";
+import { CandleChart } from "@/features/chart/candle-chart";
 import { toast } from "sonner";
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
@@ -97,88 +98,6 @@ const mockTrades: Trade[] = [
   { time: "14:31:54", price: 67835.0, qty: 0.017, side: "sell", total: 1153.2, pnl: -5.4 },
   { time: "14:31:53", price: 67851.5, qty: 0.088, side: "buy", total: 5970.93, pnl: 17.6 },
 ];
-
-// ── Candle chart ───────────────────────────────────────────────────────────────
-
-const CANDLES = [
-  { o: 67120, h: 67480, l: 67050, c: 67390 },
-  { o: 67390, h: 67620, l: 67300, c: 67580 },
-  { o: 67580, h: 67710, l: 67520, c: 67490 },
-  { o: 67490, h: 67550, l: 67320, c: 67350 },
-  { o: 67350, h: 67400, l: 67180, c: 67220 },
-  { o: 67220, h: 67680, l: 67200, c: 67650 },
-  { o: 67650, h: 67820, l: 67610, c: 67780 },
-  { o: 67780, h: 67900, l: 67730, c: 67860 },
-  { o: 67860, h: 67940, l: 67800, c: 67844 },
-];
-
-const CANDLE_MIN = 67050;
-const CANDLE_MAX = 67940;
-const CANDLE_RANGE = CANDLE_MAX - CANDLE_MIN;
-
-function pct(v: number) {
-  return ((v - CANDLE_MIN) / CANDLE_RANGE) * 100;
-}
-
-function CandleChart() {
-  return (
-    <div className="relative w-full h-full select-none">
-      <div
-        className="absolute right-2 top-1 font-mono text-[9px]"
-        style={{ color: "var(--color-muted-foreground)" }}
-      >
-        {CANDLE_MAX.toLocaleString()}
-      </div>
-      <div
-        className="absolute right-2 bottom-1 font-mono text-[9px]"
-        style={{ color: "var(--color-muted-foreground)" }}
-      >
-        {CANDLE_MIN.toLocaleString()}
-      </div>
-      {[25, 50, 75].map((y) => (
-        <div
-          key={y}
-          className="absolute w-full border-t border-dashed"
-          style={{ top: `${100 - y}%`, borderColor: "var(--color-border)" }}
-        />
-      ))}
-      <div className="absolute inset-0 flex items-end px-6 pb-2 pt-4 gap-1">
-        {CANDLES.map((c) => {
-          const bull = c.c >= c.o;
-          const color = bull ? "var(--trading-bid)" : "var(--trading-ask)";
-          const bodyTop = Math.max(pct(c.o), pct(c.c));
-          const bodyBot = Math.min(pct(c.o), pct(c.c));
-          const bodyH = Math.max(bodyTop - bodyBot, 0.5);
-          return (
-            <div
-              key={`${c.o}-${c.c}-${c.h}-${c.l}`}
-              className="flex-1 relative flex flex-col items-center justify-end h-full"
-            >
-              <div
-                className="absolute w-px"
-                style={{
-                  backgroundColor: color,
-                  bottom: `${pct(c.l)}%`,
-                  height: `${pct(c.h) - pct(c.l)}%`,
-                }}
-              />
-              <div
-                className="absolute w-3/4"
-                style={{
-                  backgroundColor: color,
-                  opacity: bull ? 0.85 : 0.7,
-                  bottom: `${bodyBot}%`,
-                  height: `${bodyH}%`,
-                  minHeight: 2,
-                }}
-              />
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
 
 // ── Panel wrapper ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Replaces the inline div-based CandleChart placeholder with a real lightweight-charts v5 candlestick chart, properly modularized in src/features/chart/.

## Changes

- **New**: src/features/chart/candle-chart.tsx — Lightweight Charts candlestick component
  - Uses createChart + addSeries(CandlestickSeries) (v5 API)
  - React 19 ref callback pattern with cleanup return (no useRef/useEffect)
  - ResizeObserver for responsive sizing
  - Reads DS color tokens at runtime via getComputedStyle
  - Mock OHLCV data with fitContent()
- **Modified**: src/routes/symbol/-trading-layout.tsx
  - Imports from @/features/chart/candle-chart instead of inline component
  - Removed ~80 lines of inline chart code (CANDLES array, pct helper, div-based renderer)

## Design System Compliance

| Token | Usage |
|-------|-------|
| --trading-bid | Up candle body color |
| --trading-ask | Down candle body color |
| --trading-tick-up | Up wick color |
| --trading-tick-down | Down wick color |
| --border | Grid lines, scale borders |
| --muted-foreground | Text labels |

## Spec AC Coverage

- **DS AC-6**: No inline style color props — old code had this anti-pattern; new code uses getComputedStyle() for the JS chart API
- **DS AC-15**: pnpm build and pnpm lint pass with no new warnings
- **Architecture spec**: Follows Presentation layer pattern — features/chart/ module imported by routes/symbol/

## Verification

- pnpm build passes
- pnpm test — all test suites pass
- No prohibited patterns (React.memo, forwardRef, useMemo, useCallback)
- No float math on financial values

Closes #8