### PR TITLE
feat(theme): add Flowa theme with dark/light/vibrant modes

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,7 +6,7 @@ import { toast, Toaster } from "sonner";
 import { ErrorBoundary } from "@/ui/error-boundary";
 import { Button } from "@/ui/button";
 
-type ThemeId = "soft" | "night-city" | "maelstrom" | "corpo-ice" | "netrunner";
+type ThemeId = "soft" | "night-city" | "maelstrom" | "corpo-ice" | "netrunner" | "flowa";
 type ModeId = "dark" | "light" | "vibrant";
 
 const THEME_STORAGE_KEY = "trading-theme";
@@ -18,6 +18,7 @@ const THEMES: { id: ThemeId; label: string; accent: string }[] = [
   { id: "maelstrom",  label: "Maelstrom",  accent: "oklch(0.56 0.28 316)" },
   { id: "corpo-ice",  label: "Corpo Ice",  accent: "oklch(0.88 0.18 215)" },
   { id: "netrunner",  label: "Netrunner",  accent: "oklch(0.62 0.22 280)" },
+  { id: "flowa",      label: "Flowa",      accent: "oklch(0.44 0.31 285)" },
 ];
 
 const MODES: { id: ModeId; icon: ReactNode; label: string }[] = [

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -180,6 +180,35 @@
   --t-destructive-fg: oklch(0.97 0    0  );
 }
 
+/* ── Flowa (purple #5F2BFF + green #c2e189) ────────────────── */
+[data-theme="flowa"] {
+  --t-hue-l: 285;
+  --t-hue-d: 285;
+  --t-chroma-l: 0.015;
+
+  --t-primary:      oklch(0.44 0.31 285);
+  --t-primary-l:    oklch(0.50 0.22 285);
+  --t-primary-fg:   oklch(0.97 0    0  );
+  --t-primary-fg-l: oklch(0.97 0    0  );
+
+  --t-bid:            oklch(0.82 0.16 140);
+  --t-bid-l:          oklch(0.44 0.14 140);
+  --t-ask:            oklch(0.65 0.22 25 );
+  --t-ask-l:          oklch(0.50 0.20 25 );
+  --t-profit:         oklch(0.82 0.16 140);
+  --t-profit-l:       oklch(0.44 0.14 140);
+  --t-loss:           oklch(0.65 0.22 25 );
+  --t-loss-l:         oklch(0.50 0.20 25 );
+  --t-reconnecting:   oklch(0.75 0.14 90 );
+  --t-reconnecting-l: oklch(0.50 0.14 90 );
+  --t-disconnected:   oklch(0.65 0.22 25 );
+  --t-disconnected-l: oklch(0.50 0.20 25 );
+
+  --t-destructive-d:  oklch(0.42 0.18 25 );
+  --t-destructive-l:  oklch(0.54 0.22 25 );
+  --t-destructive-fg: oklch(0.97 0    0  );
+}
+
 /* ============================================================
    LAYER 2 — Surface blocks
    Each block is self-contained. Trading vars use CSS Relative
@@ -1098,6 +1127,186 @@
   --trading-tick-up:      var(--t-profit);
   --trading-tick-down:    var(--t-loss);
   --trading-tick-neutral: oklch(0.60 0.010 90 );
+
+  --trading-connected:    var(--t-bid);
+  --trading-reconnecting: var(--t-reconnecting);
+  --trading-disconnected: var(--t-disconnected);
+
+  --trading-reconnecting-bg:     oklch(from var(--t-reconnecting) l c h / 0.15);
+  --trading-reconnecting-border: oklch(from var(--t-reconnecting) l c h / 0.35);
+  --trading-disconnected-bg:     oklch(from var(--t-disconnected) l c h / 0.15);
+  --trading-disconnected-border: oklch(from var(--t-disconnected) l c h / 0.35);
+}
+
+/* ════════════════════════════════════════════════════════════
+   FLOWA  ·  Purple primary — green bid, warm cream light
+   ════════════════════════════════════════════════════════════ */
+
+[data-theme="flowa"][data-mode="light"] {
+  color-scheme: light;
+  --background:             oklch(0.97 0.010 100);
+  --foreground:             oklch(0.15 0.010 285);
+  --card:                   oklch(0.99 0.008 100);
+  --card-foreground:        oklch(0.15 0.010 285);
+  --popover:                oklch(0.99 0.008 100);
+  --popover-foreground:     oklch(0.15 0.010 285);
+  --primary:                var(--t-primary-l);
+  --primary-foreground:     var(--t-primary-fg-l);
+  --secondary:              oklch(0.93 var(--t-chroma-l) var(--t-hue-l));
+  --secondary-foreground:   oklch(0.15 0.010 var(--t-hue-l));
+  --muted:                  oklch(0.93 var(--t-chroma-l) var(--t-hue-l));
+  --muted-foreground:       oklch(0.45 0.005 var(--t-hue-l));
+  --accent:                 oklch(0.93 var(--t-chroma-l) var(--t-hue-l));
+  --accent-foreground:      oklch(0.15 0.010 var(--t-hue-l));
+  --destructive:            var(--t-destructive-l);
+  --destructive-foreground: var(--t-destructive-fg);
+  --border:                 oklch(0.87 var(--t-chroma-l) var(--t-hue-l));
+  --input:                  oklch(0.96 var(--t-chroma-l) var(--t-hue-l));
+  --ring:                   var(--t-primary-l);
+
+  --ds-gray-100: oklch(0.94 var(--t-chroma-l) var(--t-hue-l));
+  --ds-gray-500: oklch(0.45 0.005 var(--t-hue-l));
+  --ds-gray-600: oklch(0.35 0.005 var(--t-hue-l));
+  --ds-gray-700: oklch(0.25 0.005 var(--t-hue-l));
+  --ds-gray-800: oklch(0.90 var(--t-chroma-l) var(--t-hue-l));
+
+  --sidebar:                    oklch(0.96 var(--t-chroma-l) var(--t-hue-l));
+  --sidebar-foreground:         oklch(0.15 0.010 var(--t-hue-l));
+  --sidebar-primary:            var(--t-primary-l);
+  --sidebar-primary-foreground: var(--t-primary-fg-l);
+  --sidebar-accent:             oklch(0.92 var(--t-chroma-l) var(--t-hue-l));
+  --sidebar-accent-foreground:  oklch(0.15 0.010 var(--t-hue-l));
+  --sidebar-border:             oklch(0.87 var(--t-chroma-l) var(--t-hue-l));
+  --sidebar-ring:               var(--t-primary-l);
+
+  --trading-bid:       var(--t-bid-l);
+  --trading-bid-muted: oklch(from var(--t-bid-l) l c h / 0.12);
+  --trading-ask:       var(--t-ask-l);
+  --trading-ask-muted: oklch(from var(--t-ask-l) l c h / 0.12);
+  --trading-profit:    var(--t-profit-l);
+  --trading-loss:      var(--t-loss-l);
+
+  --trading-tick-up:      var(--t-profit-l);
+  --trading-tick-down:    var(--t-loss-l);
+  --trading-tick-neutral: oklch(0.45 0.005 var(--t-hue-l));
+
+  --trading-connected:    var(--t-bid-l);
+  --trading-reconnecting: var(--t-reconnecting-l);
+  --trading-disconnected: var(--t-disconnected-l);
+
+  --trading-reconnecting-bg:     oklch(from var(--t-reconnecting-l) l c h / 0.10);
+  --trading-reconnecting-border: oklch(from var(--t-reconnecting-l) l c h / 0.30);
+  --trading-disconnected-bg:     oklch(from var(--t-disconnected-l) l c h / 0.10);
+  --trading-disconnected-border: oklch(from var(--t-disconnected-l) l c h / 0.30);
+}
+
+[data-theme="flowa"][data-mode="dark"] {
+  color-scheme: dark;
+  --background:             oklch(0.14 0.008 var(--t-hue-d));
+  --foreground:             oklch(0.93 0.006 var(--t-hue-d));
+  --card:                   oklch(0.18 0.010 var(--t-hue-d));
+  --card-foreground:        oklch(0.93 0.006 var(--t-hue-d));
+  --popover:                oklch(0.18 0.010 var(--t-hue-d));
+  --popover-foreground:     oklch(0.93 0.006 var(--t-hue-d));
+  --primary:                var(--t-primary);
+  --primary-foreground:     var(--t-primary-fg);
+  --secondary:              oklch(0.22 0.010 var(--t-hue-d));
+  --secondary-foreground:   oklch(0.93 0.006 var(--t-hue-d));
+  --muted:                  oklch(0.22 0.010 var(--t-hue-d));
+  --muted-foreground:       oklch(0.62 0.006 var(--t-hue-d));
+  --accent:                 oklch(0.22 0.010 var(--t-hue-d));
+  --accent-foreground:      oklch(0.93 0.006 var(--t-hue-d));
+  --destructive:            var(--t-destructive-d);
+  --destructive-foreground: var(--t-destructive-fg);
+  --border:                 oklch(0.28 0.010 var(--t-hue-d));
+  --input:                  oklch(0.24 0.010 var(--t-hue-d));
+  --ring:                   var(--t-primary);
+
+  --ds-gray-100: oklch(0.20 0.010 var(--t-hue-d));
+  --ds-gray-500: oklch(0.55 0.005 var(--t-hue-d));
+  --ds-gray-600: oklch(0.65 0.005 var(--t-hue-d));
+  --ds-gray-700: oklch(0.45 0.005 var(--t-hue-d));
+  --ds-gray-800: oklch(0.27 0.010 var(--t-hue-d));
+
+  --sidebar:                    oklch(0.22 0.010 var(--t-hue-d));
+  --sidebar-foreground:         oklch(0.93 0.006 var(--t-hue-d));
+  --sidebar-primary:            var(--t-primary);
+  --sidebar-primary-foreground: var(--t-primary-fg);
+  --sidebar-accent:             oklch(0.27 0.010 var(--t-hue-d));
+  --sidebar-accent-foreground:  oklch(0.93 0.006 var(--t-hue-d));
+  --sidebar-border:             oklch(0.28 0.010 var(--t-hue-d));
+  --sidebar-ring:               var(--t-primary);
+
+  --trading-bid:       var(--t-bid);
+  --trading-bid-muted: oklch(from var(--t-bid) l c h / 0.15);
+  --trading-ask:       var(--t-ask);
+  --trading-ask-muted: oklch(from var(--t-ask) l c h / 0.15);
+  --trading-profit:    var(--t-profit);
+  --trading-loss:      var(--t-loss);
+
+  --trading-tick-up:      var(--t-profit);
+  --trading-tick-down:    var(--t-loss);
+  --trading-tick-neutral: oklch(0.60 0.005 var(--t-hue-d));
+
+  --trading-connected:    var(--t-bid);
+  --trading-reconnecting: var(--t-reconnecting);
+  --trading-disconnected: var(--t-disconnected);
+
+  --trading-reconnecting-bg:     oklch(from var(--t-reconnecting) l c h / 0.10);
+  --trading-reconnecting-border: oklch(from var(--t-reconnecting) l c h / 0.30);
+  --trading-disconnected-bg:     oklch(from var(--t-disconnected) l c h / 0.10);
+  --trading-disconnected-border: oklch(from var(--t-disconnected) l c h / 0.30);
+}
+
+[data-theme="flowa"][data-mode="vibrant"] {
+  color-scheme: dark;
+
+  /* Purple bg — dark panels float on top */
+  --background:             oklch(0.38 0.26 285);
+  --foreground:             oklch(0.97 0.006 285);
+  --card:                   oklch(0.10 0.008 var(--t-hue-d));
+  --card-foreground:        oklch(0.90 0.006 var(--t-hue-d));
+  --popover:                oklch(0.10 0.008 var(--t-hue-d));
+  --popover-foreground:     oklch(0.90 0.006 var(--t-hue-d));
+  --primary:                var(--t-primary);
+  --primary-foreground:     var(--t-primary-fg);
+  --secondary:              oklch(0.14 0.006 var(--t-hue-d));
+  --secondary-foreground:   oklch(0.90 0.006 var(--t-hue-d));
+  --muted:                  oklch(0.14 0.006 var(--t-hue-d));
+  --muted-foreground:       oklch(0.55 0.004 var(--t-hue-d));
+  --accent:                 oklch(0.14 0.006 var(--t-hue-d));
+  --accent-foreground:      oklch(0.90 0.006 var(--t-hue-d));
+  --destructive:            var(--t-destructive-d);
+  --destructive-foreground: var(--t-destructive-fg);
+  --border:                 oklch(0.22 0.010 var(--t-hue-d));
+  --input:                  oklch(0.12 0.008 var(--t-hue-d));
+  --ring:                   var(--t-primary);
+
+  --ds-gray-100: oklch(0.13 0.006 var(--t-hue-d));
+  --ds-gray-500: oklch(0.48 0.003 var(--t-hue-d));
+  --ds-gray-600: oklch(0.60 0.003 var(--t-hue-d));
+  --ds-gray-700: oklch(0.38 0.003 var(--t-hue-d));
+  --ds-gray-800: oklch(0.18 0.008 var(--t-hue-d));
+
+  --sidebar:                    oklch(0.10 0.008 var(--t-hue-d));
+  --sidebar-foreground:         oklch(0.90 0.006 var(--t-hue-d));
+  --sidebar-primary:            var(--t-primary);
+  --sidebar-primary-foreground: var(--t-primary-fg);
+  --sidebar-accent:             oklch(0.14 0.006 var(--t-hue-d));
+  --sidebar-accent-foreground:  oklch(0.90 0.006 var(--t-hue-d));
+  --sidebar-border:             oklch(0.22 0.010 var(--t-hue-d));
+  --sidebar-ring:               var(--t-primary);
+
+  --trading-bid:       var(--t-bid);
+  --trading-bid-muted: oklch(from var(--t-bid) l c h / 0.15);
+  --trading-ask:       var(--t-ask);
+  --trading-ask-muted: oklch(from var(--t-ask) l c h / 0.15);
+  --trading-profit:    var(--t-profit);
+  --trading-loss:      var(--t-loss);
+
+  --trading-tick-up:      var(--t-profit);
+  --trading-tick-down:    var(--t-loss);
+  --trading-tick-neutral: oklch(0.60 0.010 var(--t-hue-d));
 
   --trading-connected:    var(--t-bid);
   --trading-reconnecting: var(--t-reconnecting);


### PR DESCRIPTION
## Summary

Adds the **Flowa** theme to the trading engine, based on the Flowa brand palette (purple #5F2BFF primary + green #c2e189 accents).

### Changes

| File | Change |
|---|---|
| `src/styles/tokens.css` | Layer 1 palette block `[data-theme="flowa"]` with all `--t-*` vars |
| `src/styles/tokens.css` | Layer 2 surface blocks: light, dark, vibrant modes |
| `src/routes/__root.tsx` | Added `"flowa"` to `ThemeId` union and `THEMES` array |

### Architecture

Follows the 3-layer design token system:
1. **Layer 1** — `[data-theme="flowa"]` palette identity (`--t-*` private vars, OKLCH)
2. **Layer 2** — `[data-theme="flowa"][data-mode="dark|light|vibrant"]` surface system
3. **Layer 3** — `:root` fonts/durations (unchanged)

### Verification

- ✅ `pnpm tokens` — 734 completeness checks passed
- ✅ `pnpm typecheck` — zero errors
- ✅ `pnpm build` — success (pre-existing chunk size warning only)

Closes #12