### PR TITLE
feat(order-book): split asks/bids into independent scrollable containers

### DIFF
--- a/src/features/order-book/order-book-row.test.tsx
+++ b/src/features/order-book/order-book-row.test.tsx
@@ -20,13 +20,13 @@ describe("OrderBookRow", () => {
   it("applies bid styling to side=bid", () => {
     render(<OrderBookRow level={mockLevel} side="bid" />);
     const priceCell = screen.getByText("42500.50");
-    expect(priceCell).toHaveClass("text-[color:var(--trading-bid)]");
+    expect(priceCell).toHaveClass("text-trading-bid");
   });
 
   it("applies ask styling to side=ask", () => {
     render(<OrderBookRow level={mockLevel} side="ask" />);
     const priceCell = screen.getByText("42500.50");
-    expect(priceCell).toHaveClass("text-[color:var(--trading-ask)]");
+    expect(priceCell).toHaveClass("text-trading-ask");
   });
 
   it("renders with correct layout classes", () => {

--- a/src/features/order-book/order-book-row.tsx
+++ b/src/features/order-book/order-book-row.tsx
@@ -14,8 +14,7 @@ interface OrderBookRowProps {
 }
 
 export function OrderBookRow({ level, side }: OrderBookRowProps) {
-  const textColor =
-    side === "bid" ? "text-[color:var(--trading-bid)]" : "text-[color:var(--trading-ask)]";
+  const textColor = side === "bid" ? "text-trading-bid" : "text-trading-ask";
 
   return (
     <div

--- a/src/features/order-book/order-book.test.tsx
+++ b/src/features/order-book/order-book.test.tsx
@@ -44,5 +44,37 @@ describe("OrderBook", () => {
     const { container } = render(<OrderBook state={mockState} />);
     const orderbook = container.firstChild;
     expect(orderbook).toHaveClass("flex", "flex-col", "w-full", "h-full", "font-mono", "text-sm");
+    expect(orderbook).not.toHaveClass("overflow-y-auto");
+  });
+
+  it("asks container scrolls independently", () => {
+    render(<OrderBook state={mockState} />);
+    const asksContainer = screen.getByTestId("asks-container");
+    expect(asksContainer).toHaveClass("overflow-y-auto", "flex-1");
+  });
+
+  it("bids container scrolls independently", () => {
+    render(<OrderBook state={mockState} />);
+    const bidsContainer = screen.getByTestId("bids-container");
+    expect(bidsContainer).toHaveClass("overflow-y-auto", "flex-1");
+  });
+
+  it("spread bar is not inside a scrollable container", () => {
+    const { container } = render(<OrderBook state={mockState} />);
+    const spreadText = screen.getByText(/Spread:/);
+    const rootContainer = container.firstChild;
+    // Walk up from the spread text to find the direct child of root
+    let el: HTMLElement | null = spreadText;
+    while (el && el.parentElement !== rootContainer) {
+      el = el.parentElement;
+    }
+    expect(el).not.toBeNull();
+    expect(el?.parentElement).toBe(rootContainer);
+  });
+
+  it("asks container is bottom-aligned", () => {
+    render(<OrderBook state={mockState} />);
+    const asksContainer = screen.getByTestId("asks-container");
+    expect(asksContainer).toHaveClass("justify-end");
   });
 });

--- a/src/features/order-book/order-book.tsx
+++ b/src/features/order-book/order-book.tsx
@@ -24,24 +24,22 @@ export function OrderBook({ state }: OrderBookProps) {
     <div className="flex flex-col w-full h-full font-mono text-sm">
       <ConnectionBanner status={state.connectionStatus} />
 
-      <div className="flex-1 overflow-y-auto flex flex-col">
-        {/* Asks section — highest price at top, lowest ask nearest spread */}
-        <div className="flex-1 flex flex-col justify-end space-y-px">
-          <AskTable levels={state.asks} />
-        </div>
+      {/* Asks — independent scroll, bottom-aligned */}
+      <div data-testid="asks-container" className="flex-1 min-h-0 overflow-y-auto flex flex-col justify-end">
+        <AskTable levels={state.asks} />
+      </div>
 
-        {/* Spread bar */}
-        <SpreadBar
-          lastPrice={state.lastPrice}
-          spreadAmount={state.spreadAmount}
-          spreadPercent={state.spreadPercent}
-          tickDirection={state.lastPriceTick}
-        />
+      {/* Spread bar — always visible, pinned between */}
+      <SpreadBar
+        lastPrice={state.lastPrice}
+        spreadAmount={state.spreadAmount}
+        spreadPercent={state.spreadPercent}
+        tickDirection={state.lastPriceTick}
+      />
 
-        {/* Bids section — highest bid at top, nearest spread */}
-        <div className="flex-1 space-y-px">
-          <BidTable levels={state.bids} />
-        </div>
+      {/* Bids — independent scroll */}
+      <div data-testid="bids-container" className="flex-1 min-h-0 overflow-y-auto">
+        <BidTable levels={state.bids} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Split the order book's single shared scroll container into two independent
scrollable regions (asks and bids) with the spread bar pinned between them.

## Changes

- **`order-book.tsx`**: Removed single wrapping scroll container. Each section (asks/bids) now has its own `flex-1 min-h-0 overflow-y-auto` div. SpreadBar sits at root level between them.
- **`order-book-row.tsx`**: Replaced `text-[color:var(--trading-bid)]` / `text-[color:var(--trading-ask)]` anti-pattern with proper Tailwind utilities `text-trading-bid` / `text-trading-ask`.
- **`order-book.test.tsx`**: Updated container styling assertion. Added 4 new tests: independent scroll for asks/bids, spread bar not inside scroll, asks bottom-aligned.
- **`order-book-row.test.tsx`**: Updated token class assertions to match new utilities.

## Acceptance Criteria (from #10)

- [x] Ask side has its own `overflow-y-auto` container, scrolls independently
- [x] Bid side has its own `overflow-y-auto` container, scrolls independently
- [x] `SpreadBar` is always visible — never hidden by scroll
- [x] Both sides share equal height (`flex-1` on each)
- [x] Asks render bottom-aligned (lowest ask nearest spread)
- [x] Order book tests updated for structure changes

## Test Results

All 186 tests pass (1 skipped). Build succeeds with no errors.

Closes #10