### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       - name: Check DCO sign-off on all commits
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -13,7 +13,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check PR title format
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -39,7 +39,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check required labels
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(l => l.name);
@@ -63,7 +63,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check milestone assignment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const milestone = context.payload.pull_request.milestone;
@@ -81,7 +81,7 @@ jobs:
       contents: read
     steps:
       - name: Check docs freshness on feat PRs
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const title = context.payload.pull_request.title;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,13 @@ jobs:
     name: Test + Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: pnpm
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm coverage
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: coverage


### PR DESCRIPTION
## Summary

Upgrades all GitHub Actions to versions that support Node.js 24, eliminating deprecation warnings before the forced migration on June 2, 2026.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-node` | `@v4` | `@v6` |
| `actions/upload-artifact` | `@v4` | `@v7` |
| `pnpm/action-setup` | `@v4` | `@v5` |
| `actions/github-script` | `@v7` | `@v8` |

## Acceptance Criteria
- [x] All actions updated to Node.js 24 compatible versions
- [x] No workflow logic, triggers, or job names changed
- [x] 3 workflow files updated: `test.yml`, `pr-hygiene.yml`, `dco.yml`

Closes #37