### PR TITLE
fix(chart): resolve oklch CSS vars to rgb before passing to lightweight-charts

### DIFF
--- a/src/features/chart/candle-chart.tsx
+++ b/src/features/chart/candle-chart.tsx
@@ -18,16 +18,24 @@ const MOCK_CANDLES: CandlestickData<Time>[] = [
   { time: "2024-01-09" as Time, open: 67860, high: 67940, low: 67800, close: 67844 },
 ];
 
-function cssVar(container: HTMLElement, name: string): string {
-  return getComputedStyle(container).getPropertyValue(name).trim();
+/** Resolve a CSS custom property to a browser-normalized rgb() string.
+ * lightweight-charts cannot parse oklch — the probe element forces the browser
+ * to convert the computed value to sRGB before we read it back. */
+function resolveColor(container: HTMLElement, name: string): string {
+  const probe = document.createElement("div");
+  probe.style.cssText = `position:absolute;visibility:hidden;color:var(${name})`;
+  container.appendChild(probe);
+  const color = getComputedStyle(probe).color;
+  container.removeChild(probe);
+  return color;
 }
 
 export function CandleChart() {
   const chartRef = (el: HTMLDivElement | null) => {
     if (!el) return;
 
-    const textColor = cssVar(el, "--muted-foreground");
-    const borderColor = cssVar(el, "--border");
+    const textColor = resolveColor(el, "--muted-foreground");
+    const borderColor = resolveColor(el, "--border");
 
     const chart = createChart(el, {
       layout: {
@@ -52,10 +60,10 @@ export function CandleChart() {
     });
 
     const series = chart.addSeries(CandlestickSeries, {
-      upColor: cssVar(el, "--trading-bid"),
-      downColor: cssVar(el, "--trading-ask"),
-      wickUpColor: cssVar(el, "--trading-tick-up"),
-      wickDownColor: cssVar(el, "--trading-tick-down"),
+      upColor: resolveColor(el, "--trading-bid"),
+      downColor: resolveColor(el, "--trading-ask"),
+      wickUpColor: resolveColor(el, "--trading-tick-up"),
+      wickDownColor: resolveColor(el, "--trading-tick-down"),
       borderVisible: false,
     });
 


### PR DESCRIPTION
## Problem

`CandleChart` called `getComputedStyle().getPropertyValue('--token')` and passed the raw string directly to `lightweight-charts`. Themes that reference `var()` inside `oklch()` (e.g. `oklch(0.45 0.002 var(--t-hue-l))`) resolve to an oklch string at runtime — which `lightweight-charts` cannot parse.

**Affected themes:** night-city, maelstrom, corpo-ice (any where `--t-hue-l ≠ 265`)

**Error:**
```
Failed to parse color: oklch(.45 .002 95)
```

## Fix

Replace `cssVar()` with `resolveColor()` — a probe-element pattern that forces the browser to normalise the resolved value to `rgb()`:

```ts
function resolveColor(container: HTMLElement, name: string): string {
  const probe = document.createElement("div");
  probe.style.cssText = `position:absolute;visibility:hidden;color:var(${name})`;
  container.appendChild(probe);
  const color = getComputedStyle(probe).color; // browser returns rgb()
  container.removeChild(probe);
  return color;
}
```

All 6 color reads (textColor, borderColor, upColor, downColor, wickUpColor, wickDownColor) updated.

## Files Changed

- `src/features/chart/candle-chart.tsx`

Closes #40