### PR TITLE
chore(ci): enforce develop as base branch for feature PRs

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -6,6 +6,30 @@ on:
     types: [opened, edited, synchronize, reopened, labeled, unlabeled, milestoned, demilestoned]
 
 jobs:
+  pr-hygiene-base-branch:
+    name: Base branch
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Enforce develop as base for feature PRs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const base = context.payload.pull_request.base.ref;
+            const head = context.payload.pull_request.head.ref;
+
+            // develop → main is the only PR allowed to target main
+            if (base === 'main' && head !== 'develop') {
+              core.setFailed(
+                `PRs must target \`develop\`, not \`main\`.\n` +
+                `Only the release promotion PR (develop → main) may target main.\n` +
+                `Re-open this PR with base: develop.`
+              );
+            } else {
+              core.notice(`✅ Base branch valid: ${head} → ${base}`);
+            }
+
   pr-hygiene-title:
     name: PR title format
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Agents and contributors have been branching off `main` instead of `develop`. Since `main` lags behind `develop` by all unreleased work, those branches accumulate every merged PR as stowaway diffs — polluting scope and confusing reviewers.

Recent examples: PR #35 and #36 both showed `bot-pnl-chart.tsx`, `trading-grid.tsx`, `vite.config.ts` as changes even though those files belonged to a different PR.

## Fix

Add `pr-hygiene-base-branch` CI job to `pr-hygiene.yml`:

- **Blocks** any PR where `base == main` and `head != develop`
- **Passes** feature/fix/chore PRs targeting `develop` ✅
- **Passes** the release promotion PR (`develop → main`) ✅

## Companion change

`AGENTS.md` updated locally with explicit branch rules (not committed — operational file). All agents will now read: _"Always branch from `develop`. Never create branches from `main`."_

Closes #45