### PR TITLE
ci(pr-hygiene): block PRs with Co-authored-by trailers

### DIFF
--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -146,3 +146,38 @@ jobs:
               core.notice(`✅ Docs up-to-date (ROADMAP.md and README.md updated).`);
             }
 
+
+  pr-hygiene-no-coauthor:
+    name: No Co-authored-by trailers
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+      contents: read
+    steps:
+      - name: Check commits for Co-authored-by trailers
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+
+            const violations = commits.filter(c =>
+              /^co-authored-by:/im.test(c.commit.message)
+            );
+
+            if (violations.length > 0) {
+              const list = violations
+                .map(c => `  • ${c.sha.slice(0, 7)}: ${c.commit.message.split('\n')[0]}`)
+                .join('\n');
+              core.setFailed(
+                `${violations.length} commit(s) contain a Co-authored-by trailer:\n${list}\n\n` +
+                `Remove Co-authored-by lines and amend/rebase before merging.\n` +
+                `The post-commit hook should prevent this — check your local hook setup.`
+              );
+            } else {
+              core.notice(`✅ No Co-authored-by trailers found in ${commits.length} commit(s).`);
+            }


### PR DESCRIPTION
## Summary

Adds a new `pr-hygiene-no-coauthor` CI job to `pr-hygiene.yml` that blocks merging any PR whose commits contain `Co-authored-by` trailers.

## What it does

- Fetches all commits (up to 100) in the PR via GitHub API
- Case-insensitive scan of each commit message for `Co-authored-by:`
- Fails with a list of offending SHAs + subject lines
- Points the author back to the local post-commit hook as root cause

## Why

The `post-commit` hook strips these locally, but editors, GitHub web editor, or squash merges can reintroduce them. This CI gate is the last line of defense.

Closes #46