### PR TITLE
feat(design-system): close @theme gaps and standardise token usage

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -137,3 +137,13 @@ The frontend interfaces are delivered with P0/P1. Backend implementations are a 
 - [`specs/architecture.spec.md`](specs/architecture.spec.md) — Hexagonal architecture, layers, dependency rules, domain model
 - [`specs/tech-stack.spec.md`](specs/tech-stack.spec.md) — Stack feature rationale
 - [`specs/integration-boundaries.spec.md`](specs/integration-boundaries.spec.md) — Backend swap interfaces
+
+## Design System Status
+
+| Area | Status |
+|------|--------|
+| Three-layer token architecture (`--t-*` → semantic → @theme) | ✅ Complete |
+| `@theme inline` — semantic + trading + sidebar + duration tokens | ✅ Complete (#13) |
+| Component token usage (`bg-trading-bid`, `text-trading-ask`, etc.) | ✅ Complete (#13) |
+| React composition patterns (compound components, prop grouping) | 🔄 In progress (#14) |
+| Route component extraction into `features/` + `ui/` primitives | 🔄 In progress (#15) |

--- a/src/features/bots/bot-manager-panel.tsx
+++ b/src/features/bots/bot-manager-panel.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
 import { Link } from "@tanstack/react-router";
 import { ChevronRight, Pause, Play, Plus, Square } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
 import { BotConfigForm, type BotConfigFormData } from "./bot-config-form";
 import { BotSparkline } from "./bot-sparkline";
 import type { BotInstance, BotStatus } from "./types";
@@ -11,16 +12,10 @@ interface BotManagerPanelProps {
   onCreateBot?: (data: BotConfigFormData) => void | Promise<void>;
 }
 
-function statusColor(status: BotInstance["status"]): string {
-  if (status === "running") return "var(--trading-bid)";
-  if (status === "paused") return "var(--color-muted-foreground)";
-  return "var(--trading-ask)";
-}
-
-function statusBg(status: BotInstance["status"]): string {
-  if (status === "running") return "var(--trading-bid-muted)";
-  if (status === "paused") return "var(--color-muted)";
-  return "var(--trading-ask-muted)";
+function statusClasses(status: BotInstance["status"]): string {
+  if (status === "running") return "text-trading-bid bg-trading-bid-muted";
+  if (status === "paused") return "text-muted-foreground bg-muted";
+  return "text-trading-ask bg-trading-ask-muted";
 }
 
 export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManagerPanelProps) {
@@ -37,11 +32,7 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
       <div className="px-3 pt-2 pb-1.5">
         <p className="text-[10px] font-mono text-muted-foreground">
           {runningCount} running ·{" "}
-          <span
-            style={{
-              color: totalPnl >= 0 ? "var(--trading-profit)" : "var(--trading-loss)",
-            }}
-          >
+          <span className={totalPnl >= 0 ? "text-trading-profit" : "text-trading-loss"}>
             {totalPnl >= 0 ? "+" : ""}
             {totalPnl.toFixed(2)} total P&L
           </span>{" "}
@@ -74,19 +65,27 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
 
       {/* Bot table */}
       <div className="px-3 pb-3 overflow-x-auto">
-        <table className="w-full text-xs" role="table">
+        <table className="w-full text-xs">
           <thead>
             <tr>
-              {["Name", "Strategy", "Symbol", "Status", "P&L", "Win%", "Sparkline", "Actions", ""].map(
-                (col) => (
-                  <th
-                    key={col}
-                    className="px-2 py-1.5 text-left text-[10px] text-muted-foreground font-normal uppercase tracking-wide"
-                  >
-                    {col}
-                  </th>
-                )
-              )}
+              {[
+                "Name",
+                "Strategy",
+                "Symbol",
+                "Status",
+                "P&L",
+                "Win%",
+                "Sparkline",
+                "Actions",
+                "",
+              ].map((col) => (
+                <th
+                  key={col}
+                  className="px-2 py-1.5 text-left text-[10px] text-muted-foreground font-normal uppercase tracking-wide"
+                >
+                  {col}
+                </th>
+              ))}
             </tr>
           </thead>
           <tbody>
@@ -110,13 +109,7 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
 
                   {/* Strategy */}
                   <td className="px-2 py-1.5">
-                    <span
-                      className="rounded-full px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wide"
-                      style={{
-                        backgroundColor: "var(--color-muted)",
-                        color: "var(--color-muted-foreground)",
-                      }}
-                    >
+                    <span className="rounded-full px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wide bg-muted text-muted-foreground">
                       {bot.strategy}
                     </span>
                   </td>
@@ -129,11 +122,10 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
                   {/* Status */}
                   <td className="px-2 py-1.5">
                     <span
-                      className="rounded-full px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wide font-semibold"
-                      style={{
-                        backgroundColor: statusBg(bot.status),
-                        color: statusColor(bot.status),
-                      }}
+                      className={cn(
+                        "rounded-full px-1.5 py-0.5 text-[9px] font-mono uppercase tracking-wide font-semibold",
+                        statusClasses(bot.status),
+                      )}
                     >
                       {bot.status}
                     </span>
@@ -142,10 +134,10 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
                   {/* P&L */}
                   <td className="px-2 py-1.5">
                     <span
-                      className="text-xs font-mono"
-                      style={{
-                        color: pnl >= 0 ? "var(--trading-profit)" : "var(--trading-loss)",
-                      }}
+                      className={cn(
+                        "text-xs font-mono",
+                        pnl >= 0 ? "text-trading-profit" : "text-trading-loss",
+                      )}
                     >
                       {pnl >= 0 ? "+" : ""}
                       {pnl.toFixed(2)}
@@ -166,6 +158,7 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
                       {bot.status === "running" && (
                         <>
                           <button
+                            type="button"
                             className="flex items-center justify-center w-6 h-6 rounded cursor-pointer text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                             title="Pause"
                             aria-label="Pause bot"
@@ -174,8 +167,8 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
                             <Pause size={11} />
                           </button>
                           <button
-                            className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
-                            style={{ color: "var(--trading-ask)" }}
+                            type="button"
+                            className="flex items-center justify-center w-6 h-6 rounded cursor-pointer text-trading-ask hover:text-foreground hover:bg-muted transition-colors"
                             title="Stop"
                             aria-label="Stop bot"
                             onClick={() => onStatusChange(bot.id, "stopped")}
@@ -187,8 +180,8 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
                       {bot.status === "paused" && (
                         <>
                           <button
-                            className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
-                            style={{ color: "var(--trading-bid)" }}
+                            type="button"
+                            className="flex items-center justify-center w-6 h-6 rounded cursor-pointer text-trading-bid hover:text-foreground hover:bg-muted transition-colors"
                             title="Run"
                             aria-label="Run bot"
                             onClick={() => onStatusChange(bot.id, "running")}
@@ -196,8 +189,8 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
                             <Play size={11} />
                           </button>
                           <button
-                            className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
-                            style={{ color: "var(--trading-ask)" }}
+                            type="button"
+                            className="flex items-center justify-center w-6 h-6 rounded cursor-pointer text-trading-ask hover:text-foreground hover:bg-muted transition-colors"
                             title="Stop"
                             aria-label="Stop bot"
                             onClick={() => onStatusChange(bot.id, "stopped")}
@@ -208,8 +201,8 @@ export function BotManagerPanel({ bots, onStatusChange, onCreateBot }: BotManage
                       )}
                       {bot.status === "stopped" && (
                         <button
-                          className="flex items-center justify-center w-6 h-6 rounded cursor-pointer hover:text-foreground hover:bg-muted transition-colors"
-                          style={{ color: "var(--trading-bid)" }}
+                          type="button"
+                          className="flex items-center justify-center w-6 h-6 rounded cursor-pointer text-trading-bid hover:text-foreground hover:bg-muted transition-colors"
                           title="Run"
                           aria-label="Run bot"
                           onClick={() => onStatusChange(bot.id, "running")}

--- a/src/features/order-book/connection-banner.tsx
+++ b/src/features/order-book/connection-banner.tsx
@@ -11,17 +11,8 @@ export function ConnectionBanner({ status }: ConnectionBannerProps) {
 
   if (status === "reconnecting") {
     return (
-      <div
-        className={cn(base)}
-        style={{
-          backgroundColor: "var(--trading-reconnecting-bg)",
-          borderColor: "var(--trading-reconnecting-border)",
-        }}
-      >
-        <div
-          className="w-2 h-2 rounded-full animate-pulse flex-shrink-0"
-          style={{ backgroundColor: "var(--trading-reconnecting)" }}
-        />
+      <div className={cn(base, "bg-trading-reconnecting-bg border-trading-reconnecting-border")}>
+        <div className="w-2 h-2 rounded-full animate-pulse flex-shrink-0 bg-trading-reconnecting" />
         <span>Reconnecting...</span>
       </div>
     );

--- a/src/features/order-book/spread-bar.tsx
+++ b/src/features/order-book/spread-bar.tsx
@@ -15,8 +15,8 @@ export function SpreadBar({
 }: SpreadBarProps) {
   const tickIcon = tickDirection === "up" ? "↑" : tickDirection === "down" ? "↓" : "–";
   const tickColor = {
-    up: "text-[color:var(--trading-tick-up)]",
-    down: "text-[color:var(--trading-tick-down)]",
+    up: "text-trading-tick-up",
+    down: "text-trading-tick-down",
     neutral: "text-foreground",
   }[tickDirection];
 

--- a/src/features/portfolio/balance-display.test.tsx
+++ b/src/features/portfolio/balance-display.test.tsx
@@ -37,7 +37,7 @@ describe("BalanceDisplay", () => {
       />,
     );
     const pnlElement = screen.getByText(/416\.10/);
-    expect(pnlElement).toHaveClass("text-[color:var(--trading-profit)]");
+    expect(pnlElement).toHaveClass("text-trading-profit");
   });
 
   it("renders negative PnL with loss color", () => {
@@ -45,6 +45,6 @@ describe("BalanceDisplay", () => {
       <BalanceDisplay totalBalance={10000.0} availableBalance={5000.0} unrealizedPnL={-500.0} />,
     );
     const pnlElement = screen.getByText(/-500\.00/);
-    expect(pnlElement).toHaveClass("text-[color:var(--trading-loss)]");
+    expect(pnlElement).toHaveClass("text-trading-loss");
   });
 });

--- a/src/features/portfolio/balance-display.tsx
+++ b/src/features/portfolio/balance-display.tsx
@@ -12,9 +12,7 @@ export function BalanceDisplay({
   unrealizedPnL,
 }: BalanceDisplayProps) {
   const isProfitable = unrealizedPnL >= 0;
-  const pnlColor = isProfitable
-    ? "text-[color:var(--trading-profit)]"
-    : "text-[color:var(--trading-loss)]";
+  const pnlColor = isProfitable ? "text-trading-profit" : "text-trading-loss";
 
   return (
     <div className="space-y-4 font-mono text-xs">

--- a/src/features/portfolio/position-card.test.tsx
+++ b/src/features/portfolio/position-card.test.tsx
@@ -27,7 +27,7 @@ describe("PositionCard", () => {
   it("renders positive PnL with profit color", () => {
     render(<PositionCard position={mockPosition} />);
     const pnlText = screen.getByText(/250\.00/);
-    expect(pnlText).toHaveClass("text-[color:var(--trading-profit)]");
+    expect(pnlText).toHaveClass("text-trading-profit");
   });
 
   it("renders negative PnL with loss color", () => {
@@ -38,7 +38,7 @@ describe("PositionCard", () => {
     };
     render(<PositionCard position={negativePnL} />);
     const pnlText = screen.getByText(/-100\.00/);
-    expect(pnlText).toHaveClass("text-[color:var(--trading-loss)]");
+    expect(pnlText).toHaveClass("text-trading-loss");
   });
 
   it("renders PnL percentage", () => {

--- a/src/features/portfolio/position-card.tsx
+++ b/src/features/portfolio/position-card.tsx
@@ -16,9 +16,7 @@ interface PositionCardProps {
 
 export function PositionCard({ position }: PositionCardProps) {
   const isProfitable = position.unrealizedPnL >= 0;
-  const pnlColor = isProfitable
-    ? "text-[color:var(--trading-profit)]"
-    : "text-[color:var(--trading-loss)]";
+  const pnlColor = isProfitable ? "text-trading-profit" : "text-trading-loss";
 
   return (
     <Card className="hover:border-primary/30 transition-all duration-200">

--- a/src/lib/design-tokens.ts
+++ b/src/lib/design-tokens.ts
@@ -2,12 +2,12 @@
 // Run `pnpm tokens` to regenerate.
 
 export const designTokens = {
-  "fonts": {
-    "share-tech-mono": "\"Share Tech Mono\"",
-    "orbitron": "\"Orbitron\"",
-    "fira-mono": "\"Fira Mono\""
+  fonts: {
+    "share-tech-mono": '"Share Tech Mono"',
+    orbitron: '"Orbitron"',
+    "fira-mono": '"Fira Mono"',
   },
-  "semantic": {
+  semantic: {
     "--background": "oklch(0.98 0.004 265)",
     "--foreground": "oklch(0.12 0.008 265)",
     "--card": "oklch(0.99 0.004 265)",
@@ -26,49 +26,49 @@ export const designTokens = {
     "--destructive-foreground": "oklch(0.97 0    0  )",
     "--border": "oklch(0.87 0.004 265)",
     "--input": "oklch(0.96 0.004 265)",
-    "--ring": "oklch(0.62 0.22 280)"
+    "--ring": "oklch(0.62 0.22 280)",
   },
-  "gray": {
+  gray: {
     "100": "oklch(0.94 0.004 265)",
     "500": "oklch(0.45 0.002 265)",
     "600": "oklch(0.35 0.002 265)",
     "700": "oklch(0.25 0.002 265)",
-    "800": "oklch(0.90 0.004 265)"
+    "800": "oklch(0.90 0.004 265)",
   },
-  "sidebar": {
-    "foreground": "oklch(0.12 0.008 265)",
-    "primary": "oklch(0.62 0.22 280)",
+  sidebar: {
+    foreground: "oklch(0.12 0.008 265)",
+    primary: "oklch(0.62 0.22 280)",
     "primary-foreground": "oklch(0.10 0    0  )",
-    "accent": "oklch(0.92 0.004 265)",
+    accent: "oklch(0.92 0.004 265)",
     "accent-foreground": "oklch(0.12 0.008 265)",
-    "border": "oklch(0.87 0.004 265)",
-    "ring": "oklch(0.62 0.22 280)"
+    border: "oklch(0.87 0.004 265)",
+    ring: "oklch(0.62 0.22 280)",
   },
-  "trading": {
-    "bid": "oklch(0.44 0.16 145)",
+  trading: {
+    bid: "oklch(0.44 0.16 145)",
     "bid-muted": "oklch(from oklch(0.44 0.16 145) l c h / 0.12)",
-    "ask": "oklch(0.48 0.20 25 )",
+    ask: "oklch(0.48 0.20 25 )",
     "ask-muted": "oklch(from oklch(0.48 0.20 25 ) l c h / 0.12)",
-    "profit": "oklch(0.40 0.16 145)",
-    "loss": "oklch(0.48 0.20 25 )",
+    profit: "oklch(0.40 0.16 145)",
+    loss: "oklch(0.48 0.20 25 )",
     "tick-up": "oklch(0.40 0.16 145)",
     "tick-down": "oklch(0.48 0.20 25 )",
     "tick-neutral": "oklch(0.45 0.002 265)",
-    "connected": "oklch(0.44 0.16 145)",
-    "reconnecting": "oklch(0.50 0.16 75 )",
-    "disconnected": "oklch(0.48 0.20 25 )",
+    connected: "oklch(0.44 0.16 145)",
+    reconnecting: "oklch(0.50 0.16 75 )",
+    disconnected: "oklch(0.48 0.20 25 )",
     "reconnecting-bg": "oklch(from oklch(0.50 0.16 75 ) l c h / 0.10)",
     "reconnecting-border": "oklch(from oklch(0.50 0.16 75 ) l c h / 0.30)",
     "disconnected-bg": "oklch(from oklch(0.48 0.20 25 ) l c h / 0.10)",
-    "disconnected-border": "oklch(from oklch(0.48 0.20 25 ) l c h / 0.30)"
+    "disconnected-border": "oklch(from oklch(0.48 0.20 25 ) l c h / 0.30)",
   },
-  "durations": {
-    "fast": "150ms",
-    "default": "200ms",
-    "medium": "300ms",
-    "slow": "500ms",
-    "xslow": "700ms"
-  }
+  durations: {
+    fast: "150ms",
+    default: "200ms",
+    medium: "300ms",
+    slow: "500ms",
+    xslow: "700ms",
+  },
 } as const;
 
 export type DesignTokens = typeof designTokens;
@@ -80,10 +80,18 @@ export type TokenVar =
   | `--sidebar-${string}`
   | `--trading-${string}`
   | `--duration-${string}`
-  | '--background' | '--foreground'
-  | '--card' | '--card-foreground'
-  | '--primary' | '--primary-foreground'
-  | '--secondary' | '--secondary-foreground'
-  | '--muted' | '--muted-foreground'
-  | '--border' | '--input' | '--ring'
-  | '--destructive' | '--destructive-foreground';
+  | "--background"
+  | "--foreground"
+  | "--card"
+  | "--card-foreground"
+  | "--primary"
+  | "--primary-foreground"
+  | "--secondary"
+  | "--secondary-foreground"
+  | "--muted"
+  | "--muted-foreground"
+  | "--border"
+  | "--input"
+  | "--ring"
+  | "--destructive"
+  | "--destructive-foreground";

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -30,6 +30,40 @@
   --color-input:              var(--input);
   --color-ring:               var(--ring);
 
+  /* ── Trading domain tokens ──────────────────────────────── */
+  --color-trading-bid:                  var(--trading-bid);
+  --color-trading-bid-muted:            var(--trading-bid-muted);
+  --color-trading-ask:                  var(--trading-ask);
+  --color-trading-ask-muted:            var(--trading-ask-muted);
+  --color-trading-profit:               var(--trading-profit);
+  --color-trading-loss:                 var(--trading-loss);
+  --color-trading-tick-up:              var(--trading-tick-up);
+  --color-trading-tick-down:            var(--trading-tick-down);
+  --color-trading-tick-neutral:         var(--trading-tick-neutral);
+  --color-trading-connected:            var(--trading-connected);
+  --color-trading-reconnecting:         var(--trading-reconnecting);
+  --color-trading-disconnected:         var(--trading-disconnected);
+  --color-trading-reconnecting-bg:      var(--trading-reconnecting-bg);
+  --color-trading-reconnecting-border:  var(--trading-reconnecting-border);
+  --color-trading-disconnected-bg:      var(--trading-disconnected-bg);
+  --color-trading-disconnected-border:  var(--trading-disconnected-border);
+
+  /* ── Sidebar tokens ──────────────────────────────────────── */
+  --color-sidebar:                      var(--sidebar);
+  --color-sidebar-foreground:           var(--sidebar-foreground);
+  --color-sidebar-primary:              var(--sidebar-primary);
+  --color-sidebar-primary-foreground:   var(--sidebar-primary-foreground);
+  --color-sidebar-accent:               var(--sidebar-accent);
+  --color-sidebar-accent-foreground:    var(--sidebar-accent-foreground);
+  --color-sidebar-border:               var(--sidebar-border);
+
+  /* ── Duration tokens ─────────────────────────────────────── */
+  --duration-fast:    150ms;
+  --duration-default: 200ms;
+  --duration-medium:  300ms;
+  --duration-slow:    500ms;
+  --duration-xslow:   700ms;
+
   /* ── Gray scale ────────────────────────────────────────── */
   --color-ds-gray-100: var(--ds-gray-100);
   --color-ds-gray-500: var(--ds-gray-500);

--- a/src/ui/badge.tsx
+++ b/src/ui/badge.tsx
@@ -13,11 +13,10 @@ const badgeVariants = cva("inline-flex items-center rounded font-mono transition
       // Numeric stat with dark bg
       stat: "text-xs bg-ds-gray-800 px-2 py-1",
       // Trading side badges
-      buy: "text-[10px] px-1.5 py-0.5 text-[color:var(--trading-bid)] border border-[color:var(--trading-bid)]/30",
-      sell: "text-[10px] px-1.5 py-0.5 text-[color:var(--trading-ask)] border border-[color:var(--trading-ask)]/30",
+      buy: "text-[10px] px-1.5 py-0.5 text-trading-bid border border-trading-bid/30",
+      sell: "text-[10px] px-1.5 py-0.5 text-trading-ask border border-trading-ask/30",
       // Order status
-      filled:
-        "text-[10px] px-1.5 py-0.5 text-[color:var(--trading-profit)] border border-[color:var(--trading-profit)]/30",
+      filled: "text-[10px] px-1.5 py-0.5 text-trading-profit border border-trading-profit/30",
       cancelled: "text-[10px] px-1.5 py-0.5 text-muted-foreground border border-border",
       open: "text-[10px] px-1.5 py-0.5 text-primary border border-primary/30",
     },

--- a/src/ui/button.tsx
+++ b/src/ui/button.tsx
@@ -9,8 +9,8 @@ const buttonVariants = cva(
         primary: "bg-primary text-primary-foreground hover:bg-primary/90",
         secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/90",
         danger: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        buy: "bg-[color:var(--trading-bid)] text-foreground font-medium hover:opacity-90",
-        sell: "bg-[color:var(--trading-ask)] text-foreground font-medium hover:opacity-90",
+        buy: "bg-trading-bid text-foreground font-medium hover:opacity-90",
+        sell: "bg-trading-ask text-foreground font-medium hover:opacity-90",
         ghost: "bg-transparent text-foreground hover:bg-muted",
       },
       size: {

--- a/src/ui/depth-bar.test.tsx
+++ b/src/ui/depth-bar.test.tsx
@@ -12,13 +12,13 @@ describe("DepthBar", () => {
   it("applies bid styling", () => {
     const { container } = render(<DepthBar percent={45} side="bid" />);
     const bar = container.querySelector("div");
-    expect(bar).toHaveClass("right-0", "bg-[color:var(--trading-bid)]");
+    expect(bar).toHaveClass("right-0", "bg-trading-bid");
   });
 
   it("applies ask styling", () => {
     const { container } = render(<DepthBar percent={55} side="ask" />);
     const bar = container.querySelector("div");
-    expect(bar).toHaveClass("left-0", "bg-[color:var(--trading-ask)]");
+    expect(bar).toHaveClass("left-0", "bg-trading-ask");
   });
 
   it("sets width as inline style from percent", () => {

--- a/src/ui/depth-bar.tsx
+++ b/src/ui/depth-bar.tsx
@@ -12,8 +12,8 @@ export function DepthBar({ percent, side }: DepthBarProps) {
   return (
     <div
       className={cn("absolute inset-y-0 opacity-15", {
-        "right-0 bg-[color:var(--trading-bid)]": side === "bid",
-        "left-0 bg-[color:var(--trading-ask)]": side === "ask",
+        "right-0 bg-trading-bid": side === "bid",
+        "left-0 bg-trading-ask": side === "ask",
       })}
       style={{ width: `${clampedPercent}%` }}
     />

--- a/src/ui/symbol-selector.tsx
+++ b/src/ui/symbol-selector.tsx
@@ -1,6 +1,7 @@
 import { useNavigate, useRouterState } from "@tanstack/react-router";
 import { useEffect, useRef, useState } from "react";
 import { SYMBOL_CATEGORIES, SYMBOLS, type SymbolInfo } from "@/lib/symbols";
+import { cn } from "@/lib/utils";
 
 export function SymbolSelector() {
   const [open, setOpen] = useState(false);
@@ -59,18 +60,17 @@ export function SymbolSelector() {
       <button
         type="button"
         onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-1.5 text-xs font-mono px-2.5 py-1 rounded border border-border/60 hover:border-border transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)]"
-        style={{ color: currentSymbol ? "var(--primary)" : "var(--color-muted-foreground)" }}
+        className={cn(
+          "flex items-center gap-1.5 text-xs font-mono px-2.5 py-1 rounded border border-border/60 hover:border-border transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+          currentSymbol ? "text-primary" : "text-muted-foreground",
+        )}
       >
         <span className="font-semibold">{currentSymbol ?? "SELECT PAIR"}</span>
         <span className="text-[10px] opacity-60">{open ? "▴" : "▾"}</span>
       </button>
 
       {open && (
-        <div
-          className="absolute top-full left-0 mt-1 z-50 w-56 rounded border border-border shadow-xl font-mono text-xs"
-          style={{ backgroundColor: "var(--color-card)" }}
-        >
+        <div className="absolute top-full left-0 mt-1 z-50 w-56 rounded border border-border shadow-xl font-mono text-xs bg-card">
           {/* Search input */}
           <div className="px-2 py-1.5 border-b border-border">
             <input
@@ -136,20 +136,14 @@ function SymbolRow({ info, active, onSelect }: SymbolRowProps) {
     <button
       type="button"
       onClick={() => onSelect(info.symbol)}
-      className="w-full text-left px-3 py-1.5 flex items-center gap-1 hover:bg-muted/60 transition-colors"
-      style={
-        active
-          ? { color: "var(--primary)", backgroundColor: "var(--trading-bid-muted)" }
-          : undefined
-      }
+      className={cn(
+        "w-full text-left px-3 py-1.5 flex items-center gap-1 hover:bg-muted/60 transition-colors",
+        active && "text-primary bg-trading-bid-muted",
+      )}
     >
       <span className="font-semibold tabular-nums">{info.base}</span>
       <span className="text-muted-foreground">/{info.quote}</span>
-      {active && (
-        <span className="ml-auto text-[10px]" style={{ color: "var(--primary)" }}>
-          ●
-        </span>
-      )}
+      {active && <span className="ml-auto text-[10px] text-primary">●</span>}
     </button>
   );
 }


### PR DESCRIPTION
## Summary

Closes #13. Completes the bridge between `tokens.css` semantic tokens and Tailwind utility classes, and removes all `style={{ color: 'var(...)' }}` and `bg-[color:var(...)]` patterns from `src/ui/` and `src/features/`.

## Changes

### `src/styles/app.css` — @theme completeness (AC-1, AC-2, AC-3)
- Added all **trading domain tokens**: `bg-trading-bid`, `text-trading-ask`, `text-trading-profit`, `text-trading-tick-up`, `bg-trading-reconnecting-bg`, etc.
- Added all **sidebar tokens**: `bg-sidebar`, `text-sidebar-foreground`, etc.
- Added **duration tokens**: `duration-fast`, `duration-default`, `duration-medium`, `duration-slow`, `duration-xslow`

### Component token migration (AC-4, AC-5, AC-6)
| File | Before | After |
|------|--------|-------|
| `ui/button.tsx` | `bg-[color:var(--trading-bid)]` | `bg-trading-bid` |
| `ui/badge.tsx` | `text-[color:var(--trading-ask)]` | `text-trading-ask` |
| `ui/symbol-selector.tsx` | `style={{ color: 'var(--primary)' }}` | `text-primary` |
| `ui/depth-bar.tsx` | `bg-[color:var(--trading-bid)]` | `bg-trading-bid` |
| `features/bots/bot-manager-panel.tsx` | inline style functions | `text-trading-bid/ask` classes |
| `features/order-book/connection-banner.tsx` | `style={{ backgroundColor }}` | `bg-trading-reconnecting-bg` |
| `features/order-book/spread-bar.tsx` | `text-[color:var(--trading-tick-up)]` | `text-trading-tick-up` |
| `features/portfolio/balance-display.tsx` | `text-[color:var(--trading-profit)]` | `text-trading-profit` |
| `features/portfolio/position-card.tsx` | same | same |

### Other
- `src/lib/design-tokens.ts` regenerated via `pnpm tokens` (734 checks passed)
- Updated tests to assert new semantic class names

## Validation
- ✅ `pnpm test` — 199 passed, 1 skipped
- ✅ `pnpm contrast` — 195 pairs, 0 failures, all themes/modes
- ✅ `pnpm typecheck` — clean
- ✅ `pnpm build` — builds successfully
- ✅ `pnpm tokens` — 734 checks passed
- ✅ Biome clean on all modified files

## Spec ACs covered
AC-1 ✅ AC-2 ✅ AC-3 ✅ AC-4 ✅ AC-5 ✅ AC-6 ✅ AC-7 ✅ AC-13 ✅ AC-14 ✅ AC-15 ✅