### PR TITLE
fix(design-system): correct Flowa theme palette — forest primary, secondary/accent, DS page

### DIFF
--- a/src/lib/design-tokens.ts
+++ b/src/lib/design-tokens.ts
@@ -2,12 +2,12 @@
 // Run `pnpm tokens` to regenerate.
 
 export const designTokens = {
-  fonts: {
-    "share-tech-mono": '"Share Tech Mono"',
-    orbitron: '"Orbitron"',
-    "fira-mono": '"Fira Mono"',
+  "fonts": {
+    "share-tech-mono": "\"Share Tech Mono\"",
+    "orbitron": "\"Orbitron\"",
+    "fira-mono": "\"Fira Mono\""
   },
-  semantic: {
+  "semantic": {
     "--background": "oklch(0.98 0.004 265)",
     "--foreground": "oklch(0.12 0.008 265)",
     "--card": "oklch(0.99 0.004 265)",
@@ -26,49 +26,49 @@ export const designTokens = {
     "--destructive-foreground": "oklch(0.97 0    0  )",
     "--border": "oklch(0.87 0.004 265)",
     "--input": "oklch(0.96 0.004 265)",
-    "--ring": "oklch(0.62 0.22 280)",
+    "--ring": "oklch(0.62 0.22 280)"
   },
-  gray: {
+  "gray": {
     "100": "oklch(0.94 0.004 265)",
     "500": "oklch(0.45 0.002 265)",
     "600": "oklch(0.35 0.002 265)",
     "700": "oklch(0.25 0.002 265)",
-    "800": "oklch(0.90 0.004 265)",
+    "800": "oklch(0.90 0.004 265)"
   },
-  sidebar: {
-    foreground: "oklch(0.12 0.008 265)",
-    primary: "oklch(0.62 0.22 280)",
+  "sidebar": {
+    "foreground": "oklch(0.12 0.008 265)",
+    "primary": "oklch(0.62 0.22 280)",
     "primary-foreground": "oklch(0.10 0    0  )",
-    accent: "oklch(0.92 0.004 265)",
+    "accent": "oklch(0.92 0.004 265)",
     "accent-foreground": "oklch(0.12 0.008 265)",
-    border: "oklch(0.87 0.004 265)",
-    ring: "oklch(0.62 0.22 280)",
+    "border": "oklch(0.87 0.004 265)",
+    "ring": "oklch(0.62 0.22 280)"
   },
-  trading: {
-    bid: "oklch(0.44 0.16 145)",
+  "trading": {
+    "bid": "oklch(0.44 0.16 145)",
     "bid-muted": "oklch(from oklch(0.44 0.16 145) l c h / 0.12)",
-    ask: "oklch(0.48 0.20 25 )",
+    "ask": "oklch(0.48 0.20 25 )",
     "ask-muted": "oklch(from oklch(0.48 0.20 25 ) l c h / 0.12)",
-    profit: "oklch(0.40 0.16 145)",
-    loss: "oklch(0.48 0.20 25 )",
+    "profit": "oklch(0.40 0.16 145)",
+    "loss": "oklch(0.48 0.20 25 )",
     "tick-up": "oklch(0.40 0.16 145)",
     "tick-down": "oklch(0.48 0.20 25 )",
     "tick-neutral": "oklch(0.45 0.002 265)",
-    connected: "oklch(0.44 0.16 145)",
-    reconnecting: "oklch(0.50 0.16 75 )",
-    disconnected: "oklch(0.48 0.20 25 )",
+    "connected": "oklch(0.44 0.16 145)",
+    "reconnecting": "oklch(0.50 0.16 75 )",
+    "disconnected": "oklch(0.48 0.20 25 )",
     "reconnecting-bg": "oklch(from oklch(0.50 0.16 75 ) l c h / 0.10)",
     "reconnecting-border": "oklch(from oklch(0.50 0.16 75 ) l c h / 0.30)",
     "disconnected-bg": "oklch(from oklch(0.48 0.20 25 ) l c h / 0.10)",
-    "disconnected-border": "oklch(from oklch(0.48 0.20 25 ) l c h / 0.30)",
+    "disconnected-border": "oklch(from oklch(0.48 0.20 25 ) l c h / 0.30)"
   },
-  durations: {
-    fast: "150ms",
-    default: "200ms",
-    medium: "300ms",
-    slow: "500ms",
-    xslow: "700ms",
-  },
+  "durations": {
+    "fast": "150ms",
+    "default": "200ms",
+    "medium": "300ms",
+    "slow": "500ms",
+    "xslow": "700ms"
+  }
 } as const;
 
 export type DesignTokens = typeof designTokens;
@@ -80,18 +80,10 @@ export type TokenVar =
   | `--sidebar-${string}`
   | `--trading-${string}`
   | `--duration-${string}`
-  | "--background"
-  | "--foreground"
-  | "--card"
-  | "--card-foreground"
-  | "--primary"
-  | "--primary-foreground"
-  | "--secondary"
-  | "--secondary-foreground"
-  | "--muted"
-  | "--muted-foreground"
-  | "--border"
-  | "--input"
-  | "--ring"
-  | "--destructive"
-  | "--destructive-foreground";
+  | '--background' | '--foreground'
+  | '--card' | '--card-foreground'
+  | '--primary' | '--primary-foreground'
+  | '--secondary' | '--secondary-foreground'
+  | '--muted' | '--muted-foreground'
+  | '--border' | '--input' | '--ring'
+  | '--destructive' | '--destructive-foreground';

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -19,7 +19,7 @@ const THEMES: { id: ThemeId; label: string; accent: string }[] = [
   { id: "maelstrom",  label: "Maelstrom",  accent: "oklch(0.56 0.28 316)" },
   { id: "corpo-ice",  label: "Corpo Ice",  accent: "oklch(0.88 0.18 215)" },
   { id: "netrunner",  label: "Netrunner",  accent: "oklch(0.62 0.22 280)" },
-  { id: "flowa",      label: "Flowa",      accent: "oklch(0.44 0.31 285)" },
+  { id: "flowa",      label: "Flowa",      accent: "oklch(0.21 0.030 155)" },
 ];
 
 const MODES: { id: ModeId; icon: ReactNode; label: string }[] = [

--- a/src/routes/design-system.lazy.tsx
+++ b/src/routes/design-system.lazy.tsx
@@ -23,7 +23,7 @@ export const Route = createLazyFileRoute("/design-system")({
 
 // ── Theme switcher ───────────────────────────────────────────────────────────────────────────────────
 
-type ThemeId = "soft" | "night-city" | "maelstrom" | "corpo-ice" | "netrunner";
+type ThemeId = "soft" | "night-city" | "maelstrom" | "corpo-ice" | "netrunner" | "flowa";
 type ModeId = "dark" | "light" | "vibrant";
 
 const THEMES: { id: ThemeId; label: string; accent: string }[] = [
@@ -32,6 +32,7 @@ const THEMES: { id: ThemeId; label: string; accent: string }[] = [
   { id: "maelstrom", label: "Maelstrom", accent: "oklch(0.56 0.28 316)" },
   { id: "corpo-ice", label: "Corpo Ice", accent: "oklch(0.88 0.18 215)" },
   { id: "netrunner", label: "Netrunner", accent: "oklch(0.62 0.22 280)" },
+  { id: "flowa",      label: "Flowa",      accent: "oklch(0.21 0.030 155)" },
 ];
 
 const MODES: { id: ModeId; label: string }[] = [

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -180,24 +180,55 @@
   --t-destructive-fg: oklch(0.97 0    0  );
 }
 
-/* ── Flowa (purple #5F2BFF + green #c2e189) ────────────────── */
+/* ── Flowa · Forest green (#25352D) identity ──────────────────────────────── */
 [data-theme="flowa"] {
-  --t-hue-l: 285;
-  --t-hue-d: 285;
-  --t-chroma-l: 0.015;
+  /* ── Layer 1: Flowa brand palette primitives ── */
+  --t-flowa-forest:     oklch(0.21 0.030 155);  /* #25352D deep forest green   */
+  --t-flowa-forest-mid: oklch(0.25 0.028 155);  /* slightly lighter forest     */
+  --t-flowa-forest-dim: oklch(0.18 0.025 155);  /* darker forest bg            */
+  --t-flowa-cream:      oklch(0.93 0.007 95 );  /* #E9E8E2 warm cream          */
+  --t-flowa-cream-lt:   oklch(0.97 0.005 95 );  /* lighter cream surface       */
+  /* ── Secondary: sage/lime (#c2e189) ── */
+  --t-flowa-sage:       oklch(0.79 0.08  132);  /* #AFC788 sage-light — secondary on dark  */
+  --t-flowa-sage-d:     oklch(0.46 0.09  132);  /* darker sage — secondary on light        */
+  --t-flowa-sage-muted: oklch(0.79 0.08  132 / 0.15); /* sage bg tint            */
 
-  --t-primary:      oklch(0.44 0.31 285);
-  --t-primary-l:    oklch(0.50 0.22 285);
-  --t-primary-fg:   oklch(0.97 0    0  );
-  --t-primary-fg-l: oklch(0.97 0    0  );
+  /* ── Accent/Tertiary: purple (#9354BB) ── */
+  --t-flowa-purple:     oklch(0.48 0.13  307);  /* #9354BB vibrant purple — accent on light */
+  --t-flowa-purple-lt:  oklch(0.62 0.12  307);  /* lighter purple — accent on dark          */
+  --t-flowa-purple-muted: oklch(0.48 0.13 307 / 0.15); /* purple bg tint         */
 
-  --t-bid:            oklch(0.82 0.16 140);
-  --t-bid-l:          oklch(0.44 0.14 140);
-  --t-ask:            oklch(0.65 0.22 25 );
+  /* ── Supporting palette ── */
+  --t-flowa-olive:      oklch(0.58 0.07  114);  /* #858E5B olive — borders/muted            */
+  --t-flowa-mist:       oklch(0.69 0.02  185);  /* #9FABA8 muted teal-gray — fg-muted       */
+
+  /* ── Forest variants for primary across modes ── */
+  --t-flowa-forest-bright: oklch(0.64 0.10  155);  /* bright forest — primary on dark bg  */
+
+  /* ── Primary: forest green (buttons + headings) ── */
+  --t-primary:      var(--t-flowa-forest-bright);  /* on dark bg — bright readable forest */
+  --t-primary-l:    var(--t-flowa-forest);          /* on light bg — #25352D itself        */
+  --t-primary-fg:   var(--t-flowa-cream);           /* cream text on dark-mode primary btn */
+  --t-primary-fg-l: oklch(0.97 0    0  );           /* white text on light-mode primary btn*/
+
+  /* ── Secondary: sage/lime (labels, tags, secondary buttons) ── */
+  --t-secondary:      var(--t-flowa-sage);          /* on dark bg */
+  --t-secondary-l:    var(--t-flowa-sage-d);        /* on light bg */
+  --t-secondary-fg:   oklch(0.12 0.02 155);         /* dark fg on sage button */
+
+  /* ── Accent/Tertiary: purple (info, links, tertiary actions) ── */
+  --t-accent:         var(--t-flowa-purple-lt);     /* on dark bg */
+  --t-accent-l:       var(--t-flowa-purple);        /* on light bg */
+  --t-accent-fg:      oklch(0.97 0    0  );         /* white fg on purple */
+
+  /* ── Trading: sage=bid/profit, warm-red=ask/loss ── */
+  --t-bid:            var(--t-flowa-sage);
+  --t-bid-l:          var(--t-flowa-sage-d);
+  --t-ask:            oklch(0.68 0.18 25 );
   --t-ask-l:          oklch(0.50 0.20 25 );
-  --t-profit:         oklch(0.82 0.16 140);
-  --t-profit-l:       oklch(0.44 0.14 140);
-  --t-loss:           oklch(0.65 0.22 25 );
+  --t-profit:         var(--t-flowa-sage);
+  --t-profit-l:       var(--t-flowa-sage-d);
+  --t-loss:           oklch(0.68 0.18 25 );
   --t-loss-l:         oklch(0.50 0.20 25 );
   --t-reconnecting:   oklch(0.75 0.14 90 );
   --t-reconnecting-l: oklch(0.50 0.14 90 );
@@ -1139,44 +1170,44 @@
 }
 
 /* ════════════════════════════════════════════════════════════
-   FLOWA  ·  Purple primary — green bid, warm cream light
+   FLOWA  ·  Forest primary — sage bid, purple interactive
    ════════════════════════════════════════════════════════════ */
 
 [data-theme="flowa"][data-mode="light"] {
   color-scheme: light;
-  --background:             oklch(0.97 0.010 100);
-  --foreground:             oklch(0.15 0.010 285);
-  --card:                   oklch(0.99 0.008 100);
-  --card-foreground:        oklch(0.15 0.010 285);
-  --popover:                oklch(0.99 0.008 100);
-  --popover-foreground:     oklch(0.15 0.010 285);
+  --background:             var(--t-flowa-cream);
+  --foreground:             var(--t-flowa-forest);
+  --card:                   var(--t-flowa-cream-lt);
+  --card-foreground:        var(--t-flowa-forest);
+  --popover:                var(--t-flowa-cream-lt);
+  --popover-foreground:     var(--t-flowa-forest);
   --primary:                var(--t-primary-l);
   --primary-foreground:     var(--t-primary-fg-l);
-  --secondary:              oklch(0.93 var(--t-chroma-l) var(--t-hue-l));
-  --secondary-foreground:   oklch(0.15 0.010 var(--t-hue-l));
-  --muted:                  oklch(0.93 var(--t-chroma-l) var(--t-hue-l));
-  --muted-foreground:       oklch(0.45 0.005 var(--t-hue-l));
-  --accent:                 oklch(0.93 var(--t-chroma-l) var(--t-hue-l));
-  --accent-foreground:      oklch(0.15 0.010 var(--t-hue-l));
+  --secondary:              oklch(from var(--t-secondary-l) l c h / 0.18);  /* sage tint surface */
+  --secondary-foreground:   var(--t-secondary-l);                            /* sage text         */
+  --muted:                  oklch(0.91 0.008 100);
+  --muted-foreground:       var(--t-flowa-mist);
+  --accent:                 oklch(from var(--t-accent-l) l c h / 0.15);     /* purple tint surface */
+  --accent-foreground:      var(--t-accent-l);                               /* purple text         */
   --destructive:            var(--t-destructive-l);
   --destructive-foreground: var(--t-destructive-fg);
-  --border:                 oklch(0.87 var(--t-chroma-l) var(--t-hue-l));
-  --input:                  oklch(0.96 var(--t-chroma-l) var(--t-hue-l));
+  --border:                 oklch(0.84 0.018 140);
+  --input:                  oklch(0.94 0.006 95 );
   --ring:                   var(--t-primary-l);
 
-  --ds-gray-100: oklch(0.94 var(--t-chroma-l) var(--t-hue-l));
-  --ds-gray-500: oklch(0.45 0.005 var(--t-hue-l));
-  --ds-gray-600: oklch(0.35 0.005 var(--t-hue-l));
-  --ds-gray-700: oklch(0.25 0.005 var(--t-hue-l));
-  --ds-gray-800: oklch(0.90 var(--t-chroma-l) var(--t-hue-l));
+  --ds-gray-100: oklch(0.91 0.008 100);
+  --ds-gray-500: var(--t-flowa-mist);
+  --ds-gray-600: var(--t-flowa-olive);
+  --ds-gray-700: var(--t-flowa-forest-mid);
+  --ds-gray-800: oklch(0.88 0.010 100);
 
-  --sidebar:                    oklch(0.96 var(--t-chroma-l) var(--t-hue-l));
-  --sidebar-foreground:         oklch(0.15 0.010 var(--t-hue-l));
+  --sidebar:                    oklch(0.94 0.010 140);
+  --sidebar-foreground:         var(--t-flowa-forest);
   --sidebar-primary:            var(--t-primary-l);
   --sidebar-primary-foreground: var(--t-primary-fg-l);
-  --sidebar-accent:             oklch(0.92 var(--t-chroma-l) var(--t-hue-l));
-  --sidebar-accent-foreground:  oklch(0.15 0.010 var(--t-hue-l));
-  --sidebar-border:             oklch(0.87 var(--t-chroma-l) var(--t-hue-l));
+  --sidebar-accent:             oklch(from var(--t-accent-l) l c h / 0.12);
+  --sidebar-accent-foreground:  var(--t-accent-l);
+  --sidebar-border:             oklch(0.84 0.018 140);
   --sidebar-ring:               var(--t-primary-l);
 
   --trading-bid:       var(--t-bid-l);
@@ -1188,7 +1219,7 @@
 
   --trading-tick-up:      var(--t-profit-l);
   --trading-tick-down:    var(--t-loss-l);
-  --trading-tick-neutral: oklch(0.45 0.005 var(--t-hue-l));
+  --trading-tick-neutral: var(--t-flowa-olive);
 
   --trading-connected:    var(--t-bid-l);
   --trading-reconnecting: var(--t-reconnecting-l);
@@ -1202,39 +1233,39 @@
 
 [data-theme="flowa"][data-mode="dark"] {
   color-scheme: dark;
-  --background:             oklch(0.14 0.008 var(--t-hue-d));
-  --foreground:             oklch(0.93 0.006 var(--t-hue-d));
-  --card:                   oklch(0.18 0.010 var(--t-hue-d));
-  --card-foreground:        oklch(0.93 0.006 var(--t-hue-d));
-  --popover:                oklch(0.18 0.010 var(--t-hue-d));
-  --popover-foreground:     oklch(0.93 0.006 var(--t-hue-d));
+  --background:             var(--t-flowa-forest-dim);
+  --foreground:             var(--t-flowa-cream);
+  --card:                   var(--t-flowa-forest);
+  --card-foreground:        var(--t-flowa-cream);
+  --popover:                var(--t-flowa-forest);
+  --popover-foreground:     var(--t-flowa-cream);
   --primary:                var(--t-primary);
   --primary-foreground:     var(--t-primary-fg);
-  --secondary:              oklch(0.22 0.010 var(--t-hue-d));
-  --secondary-foreground:   oklch(0.93 0.006 var(--t-hue-d));
-  --muted:                  oklch(0.22 0.010 var(--t-hue-d));
-  --muted-foreground:       oklch(0.62 0.006 var(--t-hue-d));
-  --accent:                 oklch(0.22 0.010 var(--t-hue-d));
-  --accent-foreground:      oklch(0.93 0.006 var(--t-hue-d));
+  --secondary:              oklch(from var(--t-secondary) l c h / 0.18);    /* sage tint surface */
+  --secondary-foreground:   var(--t-secondary);                              /* sage text         */
+  --muted:                  var(--t-flowa-forest-mid);
+  --muted-foreground:       var(--t-flowa-mist);
+  --accent:                 oklch(from var(--t-accent) l c h / 0.18);       /* purple tint surface */
+  --accent-foreground:      var(--t-accent);                                 /* purple text         */
   --destructive:            var(--t-destructive-d);
   --destructive-foreground: var(--t-destructive-fg);
-  --border:                 oklch(0.28 0.010 var(--t-hue-d));
-  --input:                  oklch(0.24 0.010 var(--t-hue-d));
+  --border:                 oklch(0.28 0.028 155);
+  --input:                  oklch(0.23 0.026 155);
   --ring:                   var(--t-primary);
 
-  --ds-gray-100: oklch(0.20 0.010 var(--t-hue-d));
-  --ds-gray-500: oklch(0.55 0.005 var(--t-hue-d));
-  --ds-gray-600: oklch(0.65 0.005 var(--t-hue-d));
-  --ds-gray-700: oklch(0.45 0.005 var(--t-hue-d));
-  --ds-gray-800: oklch(0.27 0.010 var(--t-hue-d));
+  --ds-gray-100: oklch(0.22 0.025 155);
+  --ds-gray-500: var(--t-flowa-mist);
+  --ds-gray-600: oklch(0.65 0.015 155);
+  --ds-gray-700: oklch(0.45 0.020 155);
+  --ds-gray-800: oklch(0.27 0.026 155);
 
-  --sidebar:                    oklch(0.22 0.010 var(--t-hue-d));
-  --sidebar-foreground:         oklch(0.93 0.006 var(--t-hue-d));
+  --sidebar:                    var(--t-flowa-forest-mid);
+  --sidebar-foreground:         var(--t-flowa-cream);
   --sidebar-primary:            var(--t-primary);
   --sidebar-primary-foreground: var(--t-primary-fg);
-  --sidebar-accent:             oklch(0.27 0.010 var(--t-hue-d));
-  --sidebar-accent-foreground:  oklch(0.93 0.006 var(--t-hue-d));
-  --sidebar-border:             oklch(0.28 0.010 var(--t-hue-d));
+  --sidebar-accent:             oklch(from var(--t-accent) l c h / 0.15);
+  --sidebar-accent-foreground:  var(--t-accent);
+  --sidebar-border:             oklch(0.28 0.028 155);
   --sidebar-ring:               var(--t-primary);
 
   --trading-bid:       var(--t-bid);
@@ -1246,7 +1277,7 @@
 
   --trading-tick-up:      var(--t-profit);
   --trading-tick-down:    var(--t-loss);
-  --trading-tick-neutral: oklch(0.60 0.005 var(--t-hue-d));
+  --trading-tick-neutral: var(--t-flowa-mist);
 
   --trading-connected:    var(--t-bid);
   --trading-reconnecting: var(--t-reconnecting);
@@ -1261,40 +1292,40 @@
 [data-theme="flowa"][data-mode="vibrant"] {
   color-scheme: dark;
 
-  /* Purple bg — dark panels float on top */
-  --background:             oklch(0.38 0.26 285);
-  --foreground:             oklch(0.97 0.006 285);
-  --card:                   oklch(0.10 0.008 var(--t-hue-d));
-  --card-foreground:        oklch(0.90 0.006 var(--t-hue-d));
-  --popover:                oklch(0.10 0.008 var(--t-hue-d));
-  --popover-foreground:     oklch(0.90 0.006 var(--t-hue-d));
+  /* Forest bg, floating cream cards — full brand saturation */
+  --background:             oklch(0.16 0.040 155);
+  --foreground:             var(--t-flowa-cream);
+  --card:                   oklch(0.12 0.020 155);
+  --card-foreground:        var(--t-flowa-cream);
+  --popover:                oklch(0.12 0.020 155);
+  --popover-foreground:     var(--t-flowa-cream);
   --primary:                var(--t-primary);
   --primary-foreground:     var(--t-primary-fg);
-  --secondary:              oklch(0.14 0.006 var(--t-hue-d));
-  --secondary-foreground:   oklch(0.90 0.006 var(--t-hue-d));
-  --muted:                  oklch(0.14 0.006 var(--t-hue-d));
-  --muted-foreground:       oklch(0.55 0.004 var(--t-hue-d));
-  --accent:                 oklch(0.14 0.006 var(--t-hue-d));
-  --accent-foreground:      oklch(0.90 0.006 var(--t-hue-d));
+  --secondary:              oklch(from var(--t-secondary) l c h / 0.20);
+  --secondary-foreground:   var(--t-secondary);
+  --muted:                  oklch(0.16 0.018 155);
+  --muted-foreground:       var(--t-flowa-mist);
+  --accent:                 oklch(from var(--t-accent) l c h / 0.20);
+  --accent-foreground:      var(--t-accent);
   --destructive:            var(--t-destructive-d);
   --destructive-foreground: var(--t-destructive-fg);
-  --border:                 oklch(0.22 0.010 var(--t-hue-d));
-  --input:                  oklch(0.12 0.008 var(--t-hue-d));
+  --border:                 oklch(0.24 0.032 155);
+  --input:                  oklch(0.14 0.022 155);
   --ring:                   var(--t-primary);
 
-  --ds-gray-100: oklch(0.13 0.006 var(--t-hue-d));
-  --ds-gray-500: oklch(0.48 0.003 var(--t-hue-d));
-  --ds-gray-600: oklch(0.60 0.003 var(--t-hue-d));
-  --ds-gray-700: oklch(0.38 0.003 var(--t-hue-d));
-  --ds-gray-800: oklch(0.18 0.008 var(--t-hue-d));
+  --ds-gray-100: oklch(0.15 0.018 155);
+  --ds-gray-500: var(--t-flowa-mist);
+  --ds-gray-600: oklch(0.62 0.012 155);
+  --ds-gray-700: oklch(0.40 0.018 155);
+  --ds-gray-800: oklch(0.20 0.022 155);
 
-  --sidebar:                    oklch(0.10 0.008 var(--t-hue-d));
-  --sidebar-foreground:         oklch(0.90 0.006 var(--t-hue-d));
+  --sidebar:                    oklch(0.14 0.022 155);
+  --sidebar-foreground:         var(--t-flowa-cream);
   --sidebar-primary:            var(--t-primary);
   --sidebar-primary-foreground: var(--t-primary-fg);
-  --sidebar-accent:             oklch(0.14 0.006 var(--t-hue-d));
-  --sidebar-accent-foreground:  oklch(0.90 0.006 var(--t-hue-d));
-  --sidebar-border:             oklch(0.22 0.010 var(--t-hue-d));
+  --sidebar-accent:             oklch(from var(--t-accent) l c h / 0.15);
+  --sidebar-accent-foreground:  var(--t-accent);
+  --sidebar-border:             oklch(0.24 0.032 155);
   --sidebar-ring:               var(--t-primary);
 
   --trading-bid:       var(--t-bid);
@@ -1306,7 +1337,7 @@
 
   --trading-tick-up:      var(--t-profit);
   --trading-tick-down:    var(--t-loss);
-  --trading-tick-neutral: oklch(0.60 0.010 var(--t-hue-d));
+  --trading-tick-neutral: var(--t-flowa-mist);
 
   --trading-connected:    var(--t-bid);
   --trading-reconnecting: var(--t-reconnecting);


### PR DESCRIPTION
Fixes #49

## Changes

### Bug 1 — Correct primary colour
- **Before**: `--primary` used purple `oklch(0.44 0.31 285)` (#5F2BFF)
- **After**: `--primary` is the **forest green** family (#25352D / oklch 155°)
  - Light mode: actual forest `oklch(0.21 0.030 155)` — dark green on cream
  - Dark mode: bright-forest `oklch(0.64 0.10 155)` — readable on dark bg
  - Applied to buttons + headings as specified

### Bug 2 — Wire the full 3-colour brand palette
Previously `--secondary` and `--accent` were identical generic formulas. Now:

| Slot | Colour | Role |
|------|--------|------|
| `--primary` | Forest `#25352D` | Buttons, headings |
| `--secondary` | Sage `#c2e189` | Labels, tags, secondary btns |
| `--accent` | Purple `#9354BB` | Info, links, tertiary actions |

All three modes (light / dark / vibrant) updated.  
Light `--background` set to `--t-flowa-cream` (#E9E8E2) per brand spec.

### Bug 3 — Flowa visible in /design-system
- `design-system.lazy.tsx` ThemeId now includes `"flowa"`
- Forest-green swatch `oklch(0.21 0.030 155)` in THEMES array
- `__root.tsx` Flowa swatch updated from purple to forest green

## Layer 1 primitives added
```
--t-flowa-forest/forest-mid/forest-dim/forest-bright
--t-flowa-cream/cream-lt
--t-flowa-sage/sage-d/sage-muted      → --secondary
--t-flowa-purple/purple-lt/purple-muted → --accent
--t-flowa-olive, --t-flowa-mist
```

## Validation
- `pnpm contrast`: 195/195 WCAG AA ✓
- `pnpm test`: 199/200 ✓
- `pnpm build`: ✓
- `pnpm tokens`: 734 checks ✓