### PR TITLE
ci(workflow): add code-quality job for lint and format

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,28 @@
+name: Code Quality
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  lint:
+    name: Lint + Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint + Format
+        run: pnpm lint


### PR DESCRIPTION
## Summary

Separates CI concerns:
- `test.yml` — tests only (`pnpm coverage`)
- `code-quality.yml` (new) — runs `pnpm lint` (biome check + ESLint) on every push/PR

## Why
Format and lint violations were silently passing CI. This gate ensures formatting, import order, and lint rules are enforced on every PR.