### PR TITLE
refactor(theme): improve flowa theme and add logo component to header

### DIFF
--- a/src/features/theme/theme-dropdown.tsx
+++ b/src/features/theme/theme-dropdown.tsx
@@ -15,7 +15,7 @@ const THEMES: { id: ThemeId; label: string; accent: string }[] = [
   { id: "maelstrom", label: "Maelstrom", accent: "oklch(0.56 0.28 316)" },
   { id: "corpo-ice", label: "Corpo Ice", accent: "oklch(0.88 0.18 215)" },
   { id: "netrunner", label: "Netrunner", accent: "oklch(0.62 0.22 280)" },
-  { id: "flowa", label: "Flowa", accent: "oklch(0.44 0.31 285)" },
+  { id: "flowa", label: "Flowa", accent: "oklch(0.79 0.08  132)" },
 ];
 
 const MODES: { id: ModeId; icon: ReactNode; label: string }[] = [

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
 import { LiveIndicator } from "@/ui/live-indicator";
 import { SymbolSelector } from "@/ui/symbol-selector";
+import { Logo } from "@/ui/logo";
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -33,6 +34,7 @@ function RootComponent() {
               to={"/" as any}
               className="font-cypher text-sm font-bold tracking-widest select-none text-primary"
             >
+              <Logo className="w-6 h-6 mr-2" />
               Trading Engine
             </Link>
             <div className="w-px h-5 bg-border mx-1" />

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -5,8 +5,8 @@ import { MOCK_NAV } from "@/lib/mock-data";
 import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
 import { LiveIndicator } from "@/ui/live-indicator";
-import { SymbolSelector } from "@/ui/symbol-selector";
 import { Logo } from "@/ui/logo";
+import { SymbolSelector } from "@/ui/symbol-selector";
 
 export const Route = createRootRoute({
   component: RootComponent,

--- a/src/routes/design-system.lazy.tsx
+++ b/src/routes/design-system.lazy.tsx
@@ -32,7 +32,7 @@ const THEMES: { id: ThemeId; label: string; accent: string }[] = [
   { id: "maelstrom", label: "Maelstrom", accent: "oklch(0.56 0.28 316)" },
   { id: "corpo-ice", label: "Corpo Ice", accent: "oklch(0.88 0.18 215)" },
   { id: "netrunner", label: "Netrunner", accent: "oklch(0.62 0.22 280)" },
-  { id: "flowa", label: "Flowa", accent: "oklch(0.21 0.030 155)" },
+  { id: "flowa", label: "Flowa", accent: "oklch(0.87 0.12 124.61)" },
 ];
 
 const MODES: { id: ModeId; label: string }[] = [
@@ -81,7 +81,7 @@ function useTheme() {
       applyTheme(t, m);
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setThemeState(t as ThemeId);
-      // eslint-disable-next-line react-hooks/set-state-in-effect
+
       setModeState(m);
     } catch {
       // storage unavailable — use defaults

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -219,7 +219,7 @@
   /* ── Accent/Tertiary: purple (info, links, tertiary actions) ── */
   --t-accent:         var(--t-flowa-purple-lt);     /* on dark bg */
   --t-accent-l:       var(--t-flowa-purple);        /* on light bg */
-  --t-accent-fg:      (oklch(0.97 0    0  ));         /* white fg on purple */
+  --t-accent-fg:      oklch(0.97 0    0  );           /* white fg on purple */
 
   /* ── Trading: sage=bid/profit, warm-red=ask/loss ── */
   --t-bid:            var(--t-flowa-sage);

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -189,7 +189,7 @@
   --t-flowa-cream:      oklch(0.93 0.007 95 );  /* #E9E8E2 warm cream          */
   --t-flowa-cream-lt:   oklch(0.97 0.005 95 );  /* lighter cream surface       */
   /* ── Secondary: sage/lime (#c2e189) ── */
-  --t-flowa-sage:       oklch(0.79 0.08  132);  /* #AFC788 sage-light — secondary on dark  */
+  --t-flowa-sage:       oklch(0.87 0.12 124.61);  /* #c2e189 sage-light — secondary on dark  */
   --t-flowa-sage-d:     oklch(0.46 0.09  132);  /* darker sage — secondary on light        */
   --t-flowa-sage-muted: oklch(0.79 0.08  132 / 0.15); /* sage bg tint            */
 
@@ -206,10 +206,10 @@
   --t-flowa-forest-bright: oklch(0.64 0.10  155);  /* bright forest — primary on dark bg  */
 
   /* ── Primary: forest green (buttons + headings) ── */
-  --t-primary:      var(--t-flowa-forest-bright);  /* on dark bg — bright readable forest */
+  --t-primary:      var(--t-flowa-sage);  /* on dark bg — bright readable forest */
   --t-primary-l:    var(--t-flowa-forest);          /* on light bg — #25352D itself        */
-  --t-primary-fg:   var(--t-flowa-cream);           /* cream text on dark-mode primary btn */
-  --t-primary-fg-l: oklch(0.97 0    0  );           /* white text on light-mode primary btn*/
+  --t-primary-fg:   var(--t-flowa-sage-d);           /* cream text on dark-mode primary btn */
+  --t-primary-fg-l: var(--t-flowa-sage);           /* white text on light-mode primary btn*/
 
   /* ── Secondary: sage/lime (labels, tags, secondary buttons) ── */
   --t-secondary:      var(--t-flowa-sage);          /* on dark bg */
@@ -219,7 +219,7 @@
   /* ── Accent/Tertiary: purple (info, links, tertiary actions) ── */
   --t-accent:         var(--t-flowa-purple-lt);     /* on dark bg */
   --t-accent-l:       var(--t-flowa-purple);        /* on light bg */
-  --t-accent-fg:      oklch(0.97 0    0  );         /* white fg on purple */
+  --t-accent-fg:      (oklch(0.97 0    0  ));         /* white fg on purple */
 
   /* ── Trading: sage=bid/profit, warm-red=ask/loss ── */
   --t-bid:            var(--t-flowa-sage);

--- a/src/ui/logo.test.tsx
+++ b/src/ui/logo.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { Logo } from "./logo";
+
+describe("Logo", () => {
+  it("renders an svg with aria-label", () => {
+    render(<Logo />);
+    expect(screen.getByRole("img", { name: "Logo" })).toBeInTheDocument();
+  });
+
+  it("applies default text-primary variant class", () => {
+    render(<Logo />);
+    expect(screen.getByRole("img").getAttribute("class")).toContain("text-primary");
+  });
+
+  it("applies subtle variant class", () => {
+    render(<Logo variant="subtle" />);
+    expect(screen.getByRole("img").getAttribute("class")).toContain("text-muted-foreground");
+  });
+
+  it("forwards custom className", () => {
+    render(<Logo className="w-8 h-8" />);
+    expect(screen.getByRole("img").getAttribute("class")).toContain("w-8");
+  });
+});

--- a/src/ui/logo.tsx
+++ b/src/ui/logo.tsx
@@ -1,0 +1,37 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "@/lib/utils";
+
+const logoVariants = cva("inline-flex items-center rounded font-mono transition-colors", {
+  variants: {
+    variant: {
+      dark: "text-primary/90 group-hover:text-primary",
+      light: "text-primary/90 group-hover:text-primary",
+      pill: "text-primary/90 group-hover:text-primary",
+    },
+  },
+  defaultVariants: {
+    variant: "pill",
+  },
+});
+
+interface LogoProps extends React.SVGAttributes<SVGSVGElement>, VariantProps<typeof logoVariants> {}
+
+export function Logo({ variant, className, ...props }: LogoProps) {
+  return (
+    <svg
+      className={cn(logoVariants({ variant }), className)}
+      {...props}
+      width="650"
+      height="621"
+      viewBox="0 0 650 621"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      role="img"
+      aria-label="Logo"
+    >
+      <rect x="283.5" y="132" width="83" height="357" fill="currentColor" />
+      <rect x="379.5" y="85" width="83" height="353" fill="currentColor" />
+      <rect x="187.5" y="179" width="83" height="357" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/ui/logo.tsx
+++ b/src/ui/logo.tsx
@@ -2,15 +2,14 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const logoVariants = cva("inline-flex items-center rounded font-mono transition-colors", {
-  variants: {
+  variants: { 
     variant: {
-      dark: "text-primary/90 group-hover:text-primary",
-      light: "text-primary/90 group-hover:text-primary",
-      pill: "text-primary/90 group-hover:text-primary",
+      default: "text-primary",
+      subtle: "text-muted-foreground",
     },
   },
   defaultVariants: {
-    variant: "pill",
+    variant: "default",
   },
 });
 

--- a/src/ui/logo.tsx
+++ b/src/ui/logo.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const logoVariants = cva("inline-flex items-center rounded font-mono transition-colors", {
-  variants: { 
+  variants: {
     variant: {
       default: "text-primary",
       subtle: "text-muted-foreground",


### PR DESCRIPTION
This pull request introduces a new reusable `Logo` component and updates the application to display the logo in the navigation bar. Additionally, it adjusts the accent color for the "Flowa" theme in two places and makes a minor cleanup in the theme state management code.

**UI Enhancements:**

* Added a new `Logo` component in `src/ui/logo.tsx` that renders an SVG logo and supports style variants using `class-variance-authority`.
* Updated the navigation bar in `src/routes/__root.tsx` to display the new `Logo` component next to the application name. [[1]](diffhunk://#diff-f8e27e284036127530471f17f7a5bdb7ac94c6fbfec767ba3a28113c09eeeb99R9) [[2]](diffhunk://#diff-f8e27e284036127530471f17f7a5bdb7ac94c6fbfec767ba3a28113c09eeeb99R37)

**Theme Updates:**

* Changed the accent color for the "Flowa" theme in both `src/features/theme/theme-dropdown.tsx` and `src/routes/design-system.lazy.tsx` to improve its appearance and consistency. [[1]](diffhunk://#diff-144dc2fff4246ebad0b111eae0902cff5ac56769719ac585b0bd3f2a1439bea6L18-R18) [[2]](diffhunk://#diff-52dfe081310cdaf13381ea4d0cd12beaf2b225e2e2b579faf014382479477256L35-R35)

**Code Cleanup:**

* Removed a redundant comment in the `useTheme` function in `src/routes/design-system.lazy.tsx` for clarity.

Closes #56