### PR TITLE
fix(order-form): 2-layer flex layout and underline tabs

### DIFF
--- a/src/features/order-entry/order-form.tsx
+++ b/src/features/order-entry/order-form.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Button } from "@/ui/button";
 import { Input } from "@/ui/input";
-import { Tab, TabList, TabPanel } from "@/ui/tabs";
+import { Tab, TabList } from "@/ui/tabs";
 
 const orderSchema = z
   .object({
@@ -65,8 +65,19 @@ export function OrderForm({ symbol, onSubmit, isLoading = false }: OrderFormProp
   };
 
   return (
-    <form onSubmit={handleSubmit(internalSubmit)} noValidate className="space-y-2.5">
-      {/* Side Selection */}
+    <form onSubmit={handleSubmit(internalSubmit)} noValidate className="flex flex-col gap-2.5">
+      {/* Order type tabs — top of form*/}
+      <TabList
+        value={type}
+        onValueChange={handleTypeChange}
+        aria-label="Order type"
+        variant="underline"
+      >
+        <Tab value="limit">Limit</Tab>
+        <Tab value="market">Market</Tab>
+      </TabList>
+
+      {/* Side toggle */}
       <div className="flex gap-1.5 bg-muted p-1 rounded-md">
         <Button
           type="button"
@@ -88,41 +99,32 @@ export function OrderForm({ symbol, onSubmit, isLoading = false }: OrderFormProp
         </Button>
       </div>
 
-      {/* Order Type Tab Switcher — uses Tab primitive */}
-      <TabList value={type} onValueChange={handleTypeChange} aria-label="Order type">
-        <Tab value="limit">Limit</Tab>
-        <Tab value="market">Market</Tab>
-      </TabList>
+      {/* Price — removed entirely on Market (no layout shift via flex-start) */}
+      {type === "limit" && (
+        <div>
+          <label htmlFor="order-price" className="text-xs text-muted-foreground block mb-1">
+            Price
+          </label>
+          <Input
+            id="order-price"
+            type="number"
+            placeholder="0.00"
+            {...register("price")}
+            disabled={busy}
+            step="0.01"
+            size="sm"
+            aria-invalid={errors.price ? "true" : undefined}
+            aria-describedby={errors.price ? "order-price-error" : undefined}
+          />
+          {errors.price && (
+            <p id="order-price-error" role="alert" className="text-xs mt-1 text-destructive">
+              {errors.price.message}
+            </p>
+          )}
+        </div>
+      )}
 
-      {/* Tab Panels — min-h prevents layout shift */}
-      <div className="min-h-[96px] space-y-2.5">
-        <TabPanel value="limit" activeValue={type}>
-          <div>
-            <label htmlFor="order-price" className="text-xs text-muted-foreground block mb-1">
-              Price
-            </label>
-            <Input
-              id="order-price"
-              type="number"
-              placeholder="0.00"
-              {...register("price")}
-              disabled={busy}
-              step="0.01"
-              size="sm"
-              aria-invalid={errors.price ? "true" : undefined}
-              aria-describedby={errors.price ? "order-price-error" : undefined}
-            />
-            {errors.price && (
-              <p id="order-price-error" role="alert" className="text-xs mt-1 text-destructive">
-                {errors.price.message}
-              </p>
-            )}
-          </div>
-        </TabPanel>
-        {/* Market panel — no price field, only quantity below */}
-      </div>
-
-      {/* Quantity Input — shared across both tabs */}
+      {/* Quantity */}
       <div>
         <label htmlFor="order-quantity" className="text-xs text-muted-foreground block mb-1">
           Quantity
@@ -162,7 +164,7 @@ export function OrderForm({ symbol, onSubmit, isLoading = false }: OrderFormProp
         ))}
       </div>
 
-      {/* Submit Button */}
+      {/* Submit */}
       <Button
         type="submit"
         intent={side === "buy" ? "buy" : "sell"}

--- a/src/ui/tabs.tsx
+++ b/src/ui/tabs.tsx
@@ -7,6 +7,7 @@ import { Button } from "./button";
 interface TabsContextValue {
   value: string;
   onValueChange: (value: string) => void;
+  variant: "pill" | "underline";
 }
 
 const TabsContext = createContext<TabsContextValue | null>(null);
@@ -22,14 +23,27 @@ function useTabsContext(): TabsContextValue {
 interface TabListProps extends React.HTMLAttributes<HTMLDivElement> {
   value: string;
   onValueChange: (value: string) => void;
+  /** Visual variant. Defaults to "pill" (filled capsule). Use "underline" for Binance-style indicator tabs. */
+  variant?: "pill" | "underline";
 }
 
-export function TabList({ value, onValueChange, className, children, ...props }: TabListProps) {
+export function TabList({
+  value,
+  onValueChange,
+  variant = "pill",
+  className,
+  children,
+  ...props
+}: TabListProps) {
   return (
-    <TabsContext value={{ value, onValueChange }}>
+    <TabsContext value={{ value, onValueChange, variant }}>
       <div
         role="tablist"
-        className={cn("flex gap-1.5 bg-muted p-1 rounded-md", className)}
+        className={cn(
+          variant === "pill" && "flex gap-1.5 bg-muted p-1 rounded-md",
+          variant === "underline" && "flex border-b border-border",
+          className,
+        )}
         {...props}
       >
         {children}
@@ -45,13 +59,12 @@ interface TabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 export function Tab({ value, children, className, ...props }: TabProps) {
-  const { value: activeValue, onValueChange } = useTabsContext();
+  const { value: activeValue, onValueChange, variant } = useTabsContext();
   const isActive = value === activeValue;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key !== "ArrowRight" && e.key !== "ArrowLeft") return;
     e.preventDefault();
-    // Query sibling tabs from the DOM at event time — no render-time ref mutation
     const tablist = e.currentTarget.closest('[role="tablist"]');
     const allTabs = Array.from(tablist?.querySelectorAll<HTMLButtonElement>('[role="tab"]') ?? []);
     const idx = allTabs.findIndex((t) => t.dataset.tab === value);
@@ -65,6 +78,30 @@ export function Tab({ value, children, className, ...props }: TabProps) {
     }
     props.onKeyDown?.(e);
   };
+
+  if (variant === "underline") {
+    return (
+      <button
+        type="button"
+        role="tab"
+        data-tab={value}
+        aria-selected={isActive}
+        tabIndex={isActive ? 0 : -1}
+        onClick={() => onValueChange(value)}
+        onKeyDown={handleKeyDown}
+        className={cn(
+          "px-3 py-2 text-sm -mb-px border-b-2 transition-colors",
+          isActive
+            ? "border-primary text-foreground font-medium"
+            : "border-transparent text-muted-foreground hover:text-foreground",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  }
 
   return (
     <Button


### PR DESCRIPTION
## Summary

Fixes order form visual and layout issues: replaces the min-h-[96px] layout hack with natural flex-start flow, and switches order type tabs to Binance-style underline indicators.

Closes #67
Closes #68

## Type

- [x] `type:bug` - fixes incorrect behavior
- [ ] `type:feat` - adds new capability
- [x] `type:ux` - improves visual output or flow
- [ ] `type:chore` - build, deps, refactor, infra

## Checklist

- [x] Tests pass (254)
- [x] Build succeeds
- [ ] CHANGELOG.md updated (user-facing changes)
- [ ] `--json` output unchanged or updated with tests

## Notes

**#67 Layout:** Form is now `flex flex-col gap-2.5` (flex-start). Price field removed entirely on Market (Binance pattern) - no reserved space, no layout shift. Removed `min-h-[96px]`.

**#68 Underline tabs:** Added `variant="underline" | "pill"` to TabList/Tab. Default stays `"pill"` for BC. Order form uses `variant="underline"`: active tab gets `border-b-2 border-primary`, no fill. Tabs placed at top of form above Buy/Sell toggle, matching Binance pattern. Keyboard arrow nav and aria-selected preserved on both variants.
