### PR TITLE
feat(trading-grid): merge bots + trades into DataPanel with tabs

### DIFF
--- a/src/features/trading/data-panel.tsx
+++ b/src/features/trading/data-panel.tsx
@@ -37,10 +37,9 @@ export function DataPanel({ bots, trades, onBotStatusChange, className }: DataPa
           onValueChange={(v) => setActiveTab(v as TabValue)}
           aria-label="Data panel"
           variant="header"
-          className="px-1"
         >
           {TABS.map((t) => (
-            <Tab key={t.value} value={t.value} className="py-2">
+            <Tab key={t.value} value={t.value}>
               {t.label}
             </Tab>
           ))}

--- a/src/features/trading/data-panel.tsx
+++ b/src/features/trading/data-panel.tsx
@@ -1,0 +1,46 @@
+import { useState } from "react";
+import { BotManagerPanel } from "@/features/bots/bot-manager-panel";
+import type { BotInstance, BotStatus } from "@/features/bots/types";
+import { RecentTradesTable } from "@/features/trades/recent-trades-table";
+import type { TradingLayoutTrade } from "@/lib/mock-data";
+import { Tab, TabList } from "@/ui/tabs";
+
+interface DataPanelProps {
+  bots: BotInstance[];
+  trades: TradingLayoutTrade[];
+  onBotStatusChange: (id: string, status: BotStatus) => void;
+}
+
+const TABS = [
+  { value: "trades", label: "Trades" },
+  { value: "bots", label: "Bots" },
+] as const;
+
+type TabValue = (typeof TABS)[number]["value"];
+
+export function DataPanel({ bots, trades, onBotStatusChange }: DataPanelProps) {
+  const [activeTab, setActiveTab] = useState<TabValue>("trades");
+
+  return (
+    <div className="h-full flex flex-col">
+      <TabList
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as TabValue)}
+        aria-label="Data panel"
+        variant="underline"
+        className="px-3 shrink-0"
+      >
+        {TABS.map((t) => (
+          <Tab key={t.value} value={t.value}>
+            {t.label}
+          </Tab>
+        ))}
+      </TabList>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        {activeTab === "trades" && <RecentTradesTable trades={trades} />}
+        {activeTab === "bots" && <BotManagerPanel bots={bots} onStatusChange={onBotStatusChange} />}
+      </div>
+    </div>
+  );
+}

--- a/src/features/trading/data-panel.tsx
+++ b/src/features/trading/data-panel.tsx
@@ -20,7 +20,7 @@ const TABS = [
 
 type TabValue = (typeof TABS)[number]["value"];
 
-/** Self-contained panel — owns its own chrome (border, header, drag handle) so tabs sit flush in the header bar, matching Chart/Book/Order panels. */
+/** Self-contained panel — owns its own chrome matching Panel header height/typography. */
 export function DataPanel({ bots, trades, onBotStatusChange, className }: DataPanelProps) {
   const [activeTab, setActiveTab] = useState<TabValue>("trades");
 
@@ -31,18 +31,16 @@ export function DataPanel({ bots, trades, onBotStatusChange, className }: DataPa
         className,
       )}
     >
-      {/* Header — cursor-move handle + tabs flush in the bar */}
       <div className="border-b border-border shrink-0 cursor-move">
         <TabList
           value={activeTab}
           onValueChange={(v) => setActiveTab(v as TabValue)}
           aria-label="Data panel"
-          variant="underline"
-          noBorder
+          variant="header"
           className="px-1"
         >
           {TABS.map((t) => (
-            <Tab key={t.value} value={t.value} className="text-xs py-2">
+            <Tab key={t.value} value={t.value} className="py-2">
               {t.label}
             </Tab>
           ))}

--- a/src/features/trading/data-panel.tsx
+++ b/src/features/trading/data-panel.tsx
@@ -3,12 +3,14 @@ import { BotManagerPanel } from "@/features/bots/bot-manager-panel";
 import type { BotInstance, BotStatus } from "@/features/bots/types";
 import { RecentTradesTable } from "@/features/trades/recent-trades-table";
 import type { TradingLayoutTrade } from "@/lib/mock-data";
+import { cn } from "@/lib/utils";
 import { Tab, TabList } from "@/ui/tabs";
 
 interface DataPanelProps {
   bots: BotInstance[];
   trades: TradingLayoutTrade[];
   onBotStatusChange: (id: string, status: BotStatus) => void;
+  className?: string;
 }
 
 const TABS = [
@@ -18,24 +20,34 @@ const TABS = [
 
 type TabValue = (typeof TABS)[number]["value"];
 
-export function DataPanel({ bots, trades, onBotStatusChange }: DataPanelProps) {
+/** Self-contained panel — owns its own chrome (border, header, drag handle) so tabs sit flush in the header bar, matching Chart/Book/Order panels. */
+export function DataPanel({ bots, trades, onBotStatusChange, className }: DataPanelProps) {
   const [activeTab, setActiveTab] = useState<TabValue>("trades");
 
   return (
-    <div className="h-full flex flex-col">
-      <TabList
-        value={activeTab}
-        onValueChange={(v) => setActiveTab(v as TabValue)}
-        aria-label="Data panel"
-        variant="underline"
-        className="px-3 shrink-0"
-      >
-        {TABS.map((t) => (
-          <Tab key={t.value} value={t.value}>
-            {t.label}
-          </Tab>
-        ))}
-      </TabList>
+    <div
+      className={cn(
+        "bg-card rounded-md border border-border flex flex-col h-full overflow-hidden",
+        className,
+      )}
+    >
+      {/* Header — cursor-move handle + tabs flush in the bar */}
+      <div className="border-b border-border shrink-0 cursor-move">
+        <TabList
+          value={activeTab}
+          onValueChange={(v) => setActiveTab(v as TabValue)}
+          aria-label="Data panel"
+          variant="underline"
+          noBorder
+          className="px-1"
+        >
+          {TABS.map((t) => (
+            <Tab key={t.value} value={t.value} className="text-xs py-2">
+              {t.label}
+            </Tab>
+          ))}
+        </TabList>
+      </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
         {activeTab === "trades" && <RecentTradesTable trades={trades} />}

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -1,12 +1,10 @@
 import { lazy, Suspense, useState } from "react";
 import { toast } from "sonner";
-import { BotManagerPanel } from "@/features/bots/bot-manager-panel";
-import type { BotStatus } from "@/features/bots/types";
 import { CandleChart } from "@/features/chart/candle-chart";
 import { OrderBook } from "@/features/order-book/order-book";
 import type { OrderFormData } from "@/features/order-entry/order-form";
 import { OrderForm } from "@/features/order-entry/order-form";
-import { RecentTradesTable } from "@/features/trades/recent-trades-table";
+import { DataPanel } from "@/features/trading/data-panel";
 import { PortfolioSummaryWidget } from "@/features/trading/portfolio-summary-widget";
 import { TickerHeader } from "@/features/trading/ticker-header";
 
@@ -155,24 +153,18 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
                 </Panel>
               </ErrorBoundary>
             </div>
-            <div key="bots">
+            <div key="data">
               <ErrorBoundary>
-                <Panel title="Bots">
-                  <Panel.Content>
-                    <BotManagerPanel
+                <Panel>
+                  <Panel.Content noScroll>
+                    <DataPanel
                       bots={bots}
-                      onStatusChange={(id: string, s: BotStatus) => setBotStatus(id, s)}
+                      trades={MOCK_TRADING_TRADES}
+                      onBotStatusChange={(id, s) => setBotStatus(id, s)}
                     />
                   </Panel.Content>
                 </Panel>
               </ErrorBoundary>
-            </div>
-            <div key="trades">
-              <Panel title="Recent Trades">
-                <Panel.Content>
-                  <RecentTradesTable trades={MOCK_TRADING_TRADES} />
-                </Panel.Content>
-              </Panel>
             </div>
           </TradingGrid>
         </Suspense>

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -155,15 +155,11 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
             </div>
             <div key="data">
               <ErrorBoundary>
-                <Panel>
-                  <Panel.Content noScroll>
-                    <DataPanel
-                      bots={bots}
-                      trades={MOCK_TRADING_TRADES}
-                      onBotStatusChange={(id, s) => setBotStatus(id, s)}
-                    />
-                  </Panel.Content>
-                </Panel>
+                <DataPanel
+                  bots={bots}
+                  trades={MOCK_TRADING_TRADES}
+                  onBotStatusChange={(id, s) => setBotStatus(id, s)}
+                />
               </ErrorBoundary>
             </div>
           </TradingGrid>

--- a/src/routes/symbol/-use-trading-layout.ts
+++ b/src/routes/symbol/-use-trading-layout.ts
@@ -10,7 +10,7 @@ import type {
 // Constants
 // ---------------------------------------------------------------------------
 
-const LAYOUT_KEY = "trading-grid-layout-v6";
+const LAYOUT_KEY = "trading-grid-layout-v7";
 
 export const BREAKPOINTS = { xxl: 1920, xl: 1440, lg: 1200, md: 996, sm: 768 } as const;
 export const COLS = { xxl: 12, xl: 12, lg: 12, md: 10, sm: 6 } as const;
@@ -27,32 +27,28 @@ export const DEFAULT_LAYOUTS: ResponsiveLayouts<string> = {
     { i: "book", x: 8, y: 0, w: 2, h: 10, minW: 2, minH: 6 },
     { i: "order", x: 10, y: 0, w: 2, h: 6, minW: 2, minH: 4 },
     { i: "portfolio", x: 10, y: 6, w: 2, h: 4, minW: 2, minH: 3 },
-    { i: "bots", x: 0, y: 10, w: 8, h: 5, minW: 4, minH: 3 },
-    { i: "trades", x: 8, y: 10, w: 4, h: 5, minW: 3, minH: 3 },
+    { i: "data", x: 0, y: 10, w: 10, h: 5, minW: 6, minH: 3 },
   ],
   xl: [
     { i: "chart", x: 0, y: 0, w: 8, h: 10, minW: 4, minH: 5 },
     { i: "book", x: 8, y: 0, w: 2, h: 10, minW: 2, minH: 6 },
     { i: "order", x: 10, y: 0, w: 2, h: 6, minW: 2, minH: 4 },
     { i: "portfolio", x: 10, y: 6, w: 2, h: 4, minW: 2, minH: 3 },
-    { i: "bots", x: 0, y: 10, w: 8, h: 5, minW: 4, minH: 3 },
-    { i: "trades", x: 8, y: 10, w: 4, h: 5, minW: 3, minH: 3 },
+    { i: "data", x: 0, y: 10, w: 10, h: 4, minW: 6, minH: 3 },
   ],
   lg: [
-    { i: "chart", x: 0, y: 0, w: 7, h: 8, minW: 4, minH: 5 },
-    { i: "book", x: 7, y: 0, w: 3, h: 8, minW: 2, minH: 6 },
-    { i: "order", x: 10, y: 0, w: 2, h: 5, minW: 2, minH: 4 },
-    { i: "portfolio", x: 10, y: 5, w: 2, h: 3, minW: 2, minH: 3 },
-    { i: "bots", x: 0, y: 8, w: 7, h: 5, minW: 4, minH: 3 },
-    { i: "trades", x: 7, y: 8, w: 5, h: 5, minW: 3, minH: 3 },
+    { i: "chart", x: 0, y: 0, w: 6, h: 10, minW: 4, minH: 5 },
+    { i: "book", x: 6, y: 0, w: 3, h: 10, minW: 2, minH: 6 },
+    { i: "order", x: 9, y: 0, w: 3, h: 6, minW: 2, minH: 4 },
+    { i: "portfolio", x: 9, y: 6, w: 3, h: 4, minW: 2, minH: 3 },
+    { i: "data", x: 0, y: 10, w: 9, h: 4, minW: 6, minH: 3 },
   ],
   md: [
-    { i: "chart", x: 0, y: 0, w: 6, h: 8, minW: 4, minH: 5 },
-    { i: "book", x: 6, y: 0, w: 4, h: 8, minW: 2, minH: 6 },
-    { i: "order", x: 0, y: 8, w: 6, h: 5, minW: 2, minH: 4 },
-    { i: "portfolio", x: 6, y: 8, w: 4, h: 5, minW: 2, minH: 3 },
-    { i: "bots", x: 0, y: 13, w: 6, h: 5, minW: 4, minH: 3 },
-    { i: "trades", x: 6, y: 13, w: 4, h: 5, minW: 3, minH: 3 },
+    { i: "chart", x: 0, y: 0, w: 5, h: 9, minW: 4, minH: 5 },
+    { i: "book", x: 5, y: 0, w: 2, h: 9, minW: 2, minH: 4 },
+    { i: "order", x: 7, y: 0, w: 3, h: 6, minW: 2, minH: 4 },
+    { i: "portfolio", x: 7, y: 6, w: 3, h: 3, minW: 2, minH: 3 },
+    { i: "data", x: 0, y: 9, w: 7, h: 4, minW: 6, minH: 3 },
   ],
 };
 
@@ -99,10 +95,8 @@ function redistributeLayout(layout: LayoutItem[], totalCols: number): LayoutItem
         return { ...item, x: sideX };
       case "portfolio":
         return { ...item, x: sideX, w: order.w };
-      case "bots":
-        return { ...item, x: 0, w: chartW };
-      case "trades":
-        return { ...item, x: chartW, w: Math.max(totalCols - chartW, 1) };
+      case "data":
+        return { ...item, x: 0, w: Math.max(totalCols - order.w, 2) };
       default:
         return item;
     }

--- a/src/routes/symbol/-use-trading-layout.ts
+++ b/src/routes/symbol/-use-trading-layout.ts
@@ -10,7 +10,7 @@ import type {
 // Constants
 // ---------------------------------------------------------------------------
 
-const LAYOUT_KEY = "trading-grid-layout-v7";
+const LAYOUT_KEY = "trading-grid-layout-v8";
 
 export const BREAKPOINTS = { xxl: 1920, xl: 1440, lg: 1200, md: 996, sm: 768 } as const;
 export const COLS = { xxl: 12, xl: 12, lg: 12, md: 10, sm: 6 } as const;
@@ -25,29 +25,29 @@ export const DEFAULT_LAYOUTS: ResponsiveLayouts<string> = {
   xxl: [
     { i: "chart", x: 0, y: 0, w: 8, h: 10, minW: 4, minH: 5 },
     { i: "book", x: 8, y: 0, w: 2, h: 10, minW: 2, minH: 6 },
-    { i: "order", x: 10, y: 0, w: 2, h: 6, minW: 2, minH: 4 },
-    { i: "portfolio", x: 10, y: 6, w: 2, h: 4, minW: 2, minH: 3 },
+    { i: "order", x: 10, y: 0, w: 2, h: 10, minW: 2, minH: 6 },
+    { i: "portfolio", x: 10, y: 10, w: 2, h: 5, minW: 2, minH: 3 },
     { i: "data", x: 0, y: 10, w: 10, h: 5, minW: 6, minH: 3 },
   ],
   xl: [
     { i: "chart", x: 0, y: 0, w: 8, h: 10, minW: 4, minH: 5 },
     { i: "book", x: 8, y: 0, w: 2, h: 10, minW: 2, minH: 6 },
-    { i: "order", x: 10, y: 0, w: 2, h: 6, minW: 2, minH: 4 },
-    { i: "portfolio", x: 10, y: 6, w: 2, h: 4, minW: 2, minH: 3 },
+    { i: "order", x: 10, y: 0, w: 2, h: 10, minW: 2, minH: 6 },
+    { i: "portfolio", x: 10, y: 10, w: 2, h: 4, minW: 2, minH: 3 },
     { i: "data", x: 0, y: 10, w: 10, h: 4, minW: 6, minH: 3 },
   ],
   lg: [
     { i: "chart", x: 0, y: 0, w: 6, h: 10, minW: 4, minH: 5 },
     { i: "book", x: 6, y: 0, w: 3, h: 10, minW: 2, minH: 6 },
-    { i: "order", x: 9, y: 0, w: 3, h: 6, minW: 2, minH: 4 },
-    { i: "portfolio", x: 9, y: 6, w: 3, h: 4, minW: 2, minH: 3 },
+    { i: "order", x: 9, y: 0, w: 3, h: 10, minW: 2, minH: 6 },
+    { i: "portfolio", x: 9, y: 10, w: 3, h: 4, minW: 2, minH: 3 },
     { i: "data", x: 0, y: 10, w: 9, h: 4, minW: 6, minH: 3 },
   ],
   md: [
     { i: "chart", x: 0, y: 0, w: 5, h: 9, minW: 4, minH: 5 },
     { i: "book", x: 5, y: 0, w: 2, h: 9, minW: 2, minH: 4 },
-    { i: "order", x: 7, y: 0, w: 3, h: 6, minW: 2, minH: 4 },
-    { i: "portfolio", x: 7, y: 6, w: 3, h: 3, minW: 2, minH: 3 },
+    { i: "order", x: 7, y: 0, w: 3, h: 9, minW: 2, minH: 6 },
+    { i: "portfolio", x: 7, y: 9, w: 3, h: 4, minW: 2, minH: 3 },
     { i: "data", x: 0, y: 9, w: 7, h: 4, minW: 6, minH: 3 },
   ],
 };

--- a/src/ui/tabs.tsx
+++ b/src/ui/tabs.tsx
@@ -25,12 +25,15 @@ interface TabListProps extends React.HTMLAttributes<HTMLDivElement> {
   onValueChange: (value: string) => void;
   /** Visual variant. Defaults to "pill" (filled capsule). Use "underline" for Binance-style indicator tabs. */
   variant?: "pill" | "underline";
+  /** When true, suppresses the bottom border on the underline variant (use when hosted inside a container that already has a border-b). */
+  noBorder?: boolean;
 }
 
 export function TabList({
   value,
   onValueChange,
   variant = "pill",
+  noBorder = false,
   className,
   children,
   ...props
@@ -41,7 +44,7 @@ export function TabList({
         role="tablist"
         className={cn(
           variant === "pill" && "flex gap-1.5 bg-muted p-1 rounded-md",
-          variant === "underline" && "flex border-b border-border",
+          variant === "underline" && cn("flex", !noBorder && "border-b border-border"),
           className,
         )}
         {...props}

--- a/src/ui/tabs.tsx
+++ b/src/ui/tabs.tsx
@@ -24,7 +24,7 @@ const tabVariants = cva(
         pill: "",
         underline: "px-3 py-2 text-sm -mb-px border-b-2",
         header:
-          "self-stretch flex items-center px-3 text-xs font-cypher font-semibold tracking-wide uppercase -mb-px border-b-2",
+          "self-stretch flex items-center px-3 text-xs leading-4 font-cypher font-semibold tracking-wide uppercase -mb-px border-b-2",
       },
       active: {
         true: "",

--- a/src/ui/tabs.tsx
+++ b/src/ui/tabs.tsx
@@ -10,7 +10,7 @@ const tabListVariants = cva("flex", {
     variant: {
       pill: "gap-1.5 bg-muted p-1 rounded-md",
       underline: "border-b border-border",
-      header: "border-b border-border",
+      header: "min-h-[2.25rem] border-b border-border",
     },
   },
   defaultVariants: { variant: "pill" },
@@ -24,7 +24,7 @@ const tabVariants = cva(
         pill: "",
         underline: "px-3 py-2 text-sm -mb-px border-b-2",
         header:
-          "px-3 py-2 text-xs font-cypher font-semibold tracking-wide uppercase -mb-px border-b-2",
+          "self-stretch flex items-center px-3 text-xs font-cypher font-semibold tracking-wide uppercase -mb-px border-b-2",
       },
       active: {
         true: "",

--- a/src/ui/tabs.tsx
+++ b/src/ui/tabs.tsx
@@ -1,13 +1,70 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import { createContext, use } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "./button";
 
+// ── CVA ───────────────────────────────────────────────────────────────────────
+
+const tabListVariants = cva("flex", {
+  variants: {
+    variant: {
+      pill: "gap-1.5 bg-muted p-1 rounded-md",
+      underline: "border-b border-border",
+      header: "border-b border-border",
+    },
+  },
+  defaultVariants: { variant: "pill" },
+});
+
+const tabVariants = cva(
+  "transition-colors select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)]",
+  {
+    variants: {
+      variant: {
+        pill: "",
+        underline: "px-3 py-2 text-sm -mb-px border-b-2",
+        header:
+          "px-3 py-2 text-xs font-cypher font-semibold tracking-wide uppercase -mb-px border-b-2",
+      },
+      active: {
+        true: "",
+        false: "",
+      },
+    },
+    compoundVariants: [
+      {
+        variant: "underline",
+        active: true,
+        className: "border-primary text-foreground font-medium",
+      },
+      {
+        variant: "underline",
+        active: false,
+        className: "border-transparent text-muted-foreground hover:text-foreground",
+      },
+      {
+        variant: "header",
+        active: true,
+        className: "border-primary text-foreground",
+      },
+      {
+        variant: "header",
+        active: false,
+        className: "border-transparent text-muted-foreground hover:text-foreground",
+      },
+    ],
+    defaultVariants: { variant: "pill", active: false },
+  },
+);
+
 // ── Context ───────────────────────────────────────────────────────────────────
+
+type TabVariant = NonNullable<VariantProps<typeof tabListVariants>["variant"]>;
 
 interface TabsContextValue {
   value: string;
   onValueChange: (value: string) => void;
-  variant: "pill" | "underline";
+  variant: TabVariant;
 }
 
 const TabsContext = createContext<TabsContextValue | null>(null);
@@ -23,32 +80,20 @@ function useTabsContext(): TabsContextValue {
 interface TabListProps extends React.HTMLAttributes<HTMLDivElement> {
   value: string;
   onValueChange: (value: string) => void;
-  /** Visual variant. Defaults to "pill" (filled capsule). Use "underline" for Binance-style indicator tabs. */
-  variant?: "pill" | "underline";
-  /** When true, suppresses the bottom border on the underline variant (use when hosted inside a container that already has a border-b). */
-  noBorder?: boolean;
+  variant?: TabVariant;
 }
 
 export function TabList({
   value,
   onValueChange,
   variant = "pill",
-  noBorder = false,
   className,
   children,
   ...props
 }: TabListProps) {
   return (
     <TabsContext value={{ value, onValueChange, variant }}>
-      <div
-        role="tablist"
-        className={cn(
-          variant === "pill" && "flex gap-1.5 bg-muted p-1 rounded-md",
-          variant === "underline" && cn("flex", !noBorder && "border-b border-border"),
-          className,
-        )}
-        {...props}
-      >
+      <div role="tablist" className={cn(tabListVariants({ variant }), className)} {...props}>
         {children}
       </div>
     </TabsContext>
@@ -82,7 +127,7 @@ export function Tab({ value, children, className, ...props }: TabProps) {
     props.onKeyDown?.(e);
   };
 
-  if (variant === "underline") {
+  if (variant === "underline" || variant === "header") {
     return (
       <button
         type="button"
@@ -92,13 +137,7 @@ export function Tab({ value, children, className, ...props }: TabProps) {
         tabIndex={isActive ? 0 : -1}
         onClick={() => onValueChange(value)}
         onKeyDown={handleKeyDown}
-        className={cn(
-          "px-3 py-2 text-sm -mb-px border-b-2 transition-colors",
-          isActive
-            ? "border-primary text-foreground font-medium"
-            : "border-transparent text-muted-foreground hover:text-foreground",
-          className,
-        )}
+        className={cn(tabVariants({ variant, active: isActive }), className)}
         {...props}
       >
         {children}

--- a/src/ui/tabs.tsx
+++ b/src/ui/tabs.tsx
@@ -10,7 +10,7 @@ const tabListVariants = cva("flex", {
     variant: {
       pill: "gap-1.5 bg-muted p-1 rounded-md",
       underline: "border-b border-border",
-      header: "min-h-[2.25rem] border-b border-border",
+      header: "min-h-9",
     },
   },
   defaultVariants: { variant: "pill" },
@@ -22,9 +22,9 @@ const tabVariants = cva(
     variants: {
       variant: {
         pill: "",
-        underline: "px-3 py-2 text-sm -mb-px border-b-2",
+        underline: "px-3 py-2 text-sm -mb-px border-b-1",
         header:
-          "self-stretch flex items-center px-3 text-xs leading-4 font-cypher font-semibold tracking-wide uppercase -mb-px border-b-2",
+          "self-stretch flex items-center px-3 text-xs leading-4 font-cypher font-semibold tracking-wide uppercase -mb-px border-b-1",
       },
       active: {
         true: "",


### PR DESCRIPTION
## Summary
Merges the separate Bots and Trades grid cells into a single tabbed `DataPanel` component (closes #76).

## Changes
- **New**: `src/features/trading/data-panel.tsx` — tabbed panel (Trades | Bots) using `variant="underline"` tabs
- **Updated**: `-use-trading-layout.ts` — replaced `bots`/`trades` keys with single `data` key; updated `redistributeLayout()`; bumped `LAYOUT_KEY` to v7
- **Updated**: `-trading-layout.tsx` — replaced two grid items with `<DataPanel>`, cleaned up unused imports

## How to Test
1. Navigate to the trading terminal
2. Verify the bottom panel shows Trades and Bots tabs
3. Switch between tabs
4. Drag/resize the panel — it spans chart + book width

## Related
Closes #76
