### PR TITLE
fix(design-system): enforce cursor-pointer on all interactive UI primitives

### DIFF
--- a/src/ui/button.tsx
+++ b/src/ui/button.tsx
@@ -2,7 +2,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center rounded-md font-normal transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)] disabled:opacity-50 disabled:cursor-not-allowed",
+  "inline-flex items-center justify-center rounded-md font-normal transition-colors cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)] disabled:opacity-50 disabled:cursor-not-allowed",
   {
     variants: {
       intent: {

--- a/src/ui/symbol-row.tsx
+++ b/src/ui/symbol-row.tsx
@@ -13,7 +13,7 @@ export function SymbolRow({ info, active, onSelect }: SymbolRowProps) {
       type="button"
       onClick={() => onSelect(info.symbol)}
       className={cn(
-        "w-full text-left px-3 py-1.5 flex items-center gap-1 hover:bg-muted/60 transition-colors",
+        "w-full cursor-pointer text-left px-3 py-1.5 flex items-center gap-1 hover:bg-muted/60 transition-colors",
         active && "text-primary bg-trading-bid-muted",
       )}
     >

--- a/src/ui/symbol-selector.tsx
+++ b/src/ui/symbol-selector.tsx
@@ -64,10 +64,10 @@ export function SymbolSelector({ triggerClassName }: SymbolSelectorProps = {}) {
           triggerClassName
             ? cn(
                 triggerClassName,
-                "flex items-center gap-1 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                "flex items-center gap-1 cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
               )
             : cn(
-                "flex items-center gap-1.5 text-xs font-mono px-2.5 py-1 rounded border border-border/60 hover:border-border transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
+                "flex items-center gap-1.5 cursor-pointer text-xs font-mono px-2.5 py-1 rounded border border-border/60 hover:border-border transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-ring",
                 currentSymbol ? "text-primary" : "text-muted-foreground",
               ),
         )}

--- a/src/ui/tabs.tsx
+++ b/src/ui/tabs.tsx
@@ -17,7 +17,7 @@ const tabListVariants = cva("flex", {
 });
 
 const tabVariants = cva(
-  "transition-colors select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)]",
+  "cursor-pointer transition-colors select-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-[var(--primary)]",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## Summary
Closes #80. Browsers default `<button>` to `cursor: default` — bakes `cursor-pointer` into CVA base styles of all interactive primitives.

## Changes
- `button.tsx` — added to `buttonVariants` base
- `tabs.tsx` — added to `tabVariants` base  
- `symbol-row.tsx` — added to button className
- `symbol-selector.tsx` — added to both trigger variants

## Test
254 tests passing, typecheck clean.