### PR TITLE
feat(header): route-aware header — logo-only + TickerHeader on symbol route

### DIFF
--- a/src/features/trading/ticker-header.tsx
+++ b/src/features/trading/ticker-header.tsx
@@ -16,7 +16,7 @@ const OHLV = [
 export function TickerHeader({ price, changePct }: TickerHeaderProps) {
   const isPositive = changePct >= 0;
   return (
-    <div className="flex items-center gap-6 py-2 border-b border-border mb-2">
+    <div className="flex items-center gap-6 h-full">
       <SymbolSelector triggerClassName="font-cypher text-base font-bold text-primary hover:text-primary/80" />
       <span className="font-mono text-xl tabular-nums font-semibold text-trading-tick-up">
         {price.toLocaleString("en-US", { minimumFractionDigits: 2 })}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,14 +1,13 @@
-import { createRootRoute, Link, Outlet } from "@tanstack/react-router";
+import { createRootRoute, Link, Outlet, useRouterState } from "@tanstack/react-router";
 import { Toaster, toast } from "sonner";
 import { ThemeDropdown } from "@/features/theme/theme-dropdown";
+import { TickerHeader } from "@/features/trading/ticker-header";
+import { MOCK_BASE_BTC, MOCK_CHANGE_PCT } from "@/lib/mock-data";
 import { useTradingStore } from "@/stores/trading-store";
 import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
 import { LiveIndicator } from "@/ui/live-indicator";
 import { Logo } from "@/ui/logo";
-import { useRouterState } from "@tanstack/react-router";
-import { TickerHeader } from "@/features/trading/ticker-header";
-import { MOCK_BASE_BTC, MOCK_CHANGE_PCT } from "@/lib/mock-data";
 
 export const Route = createRootRoute({
   component: RootComponent,
@@ -16,7 +15,7 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
-  const isSymbolRoute = pathname.startsWith('/symbol/');
+  const isSymbolRoute = pathname.startsWith("/symbol/");
   const totalBalance = useTradingStore((s) => s.portfolioSummary.totalBalance);
   const dailyProfitPct = useTradingStore((s) => s.portfolioSummary.dailyProfitPct);
 

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -6,12 +6,17 @@ import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
 import { LiveIndicator } from "@/ui/live-indicator";
 import { Logo } from "@/ui/logo";
+import { useRouterState } from "@tanstack/react-router";
+import { TickerHeader } from "@/features/trading/ticker-header";
+import { MOCK_BASE_BTC, MOCK_CHANGE_PCT } from "@/lib/mock-data";
 
 export const Route = createRootRoute({
   component: RootComponent,
 });
 
 function RootComponent() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const isSymbolRoute = pathname.startsWith('/symbol/');
   const totalBalance = useTradingStore((s) => s.portfolioSummary.totalBalance);
   const dailyProfitPct = useTradingStore((s) => s.portfolioSummary.dailyProfitPct);
 
@@ -36,9 +41,10 @@ function RootComponent() {
               to={"/" as any}
               className="font-cypher text-sm font-bold tracking-widest select-none text-primary"
             >
-              <Logo className="w-6 h-6 mr-2" />
-              Trading Engine
+              <Logo className="w-6 h-6" />
+              {!isSymbolRoute && <span className="ml-2">Trading Engine</span>}
             </Link>
+            {isSymbolRoute && <TickerHeader price={MOCK_BASE_BTC} changePct={MOCK_CHANGE_PCT} />}
             <div className="flex-1" />
             <Link
               to="/portfolio"

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -6,11 +6,8 @@ import type { OrderFormData } from "@/features/order-entry/order-form";
 import { OrderForm } from "@/features/order-entry/order-form";
 import { DataPanel } from "@/features/trading/data-panel";
 import { PortfolioSummaryWidget } from "@/features/trading/portfolio-summary-widget";
-import { TickerHeader } from "@/features/trading/ticker-header";
 
 import {
-  MOCK_BASE_BTC,
-  MOCK_CHANGE_PCT,
   MOCK_ORDER_BOOK_STATE,
   MOCK_PORTFOLIO_SUMMARY,
   MOCK_TRADING_TRADES,
@@ -86,7 +83,6 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
   return (
     <ErrorBoundary>
       <div className="w-full px-3 pb-3 flex flex-col gap-0">
-        <TickerHeader price={MOCK_BASE_BTC} changePct={MOCK_CHANGE_PCT} />
         <Suspense
           fallback={
             <div className="w-full h-[600px] grid grid-cols-12 gap-2 p-3">


### PR DESCRIPTION
## Summary

Makes the app header route-aware. On the symbol trading terminal (`/symbol/$symbol`), the header switches to a compact mode: Logo icon only (no brand text) with `<TickerHeader>` rendered inline in the same `h-12` bar. On all other routes the header is unchanged.

Closes #84

## Acceptance Criteria

- [x] Root/portfolio routes: header unchanged (Logo + "Trading Engine" text + portfolio widget + ThemeDropdown + LiveIndicator)
- [x] Symbol route: header shows Logo icon only (no brand text), immediately followed by `TickerHeader` in the same header bar
- [x] `TickerHeader` is removed from the trading grid on the symbol route (no duplicate rendering)
- [x] Header height stays at `h-12` on both routes
- [x] No layout shift when navigating between root and symbol routes
- [x] `useRouterState` used to detect current route (not prop drilling)
- [x] `__root.tsx` and `-trading-layout.tsx` use Python atomic write

## Changes

- `src/routes/__root.tsx`: added `useRouterState` to detect `/symbol/` pathname; Logo-only when `isSymbolRoute`, inline `<TickerHeader>` after Logo on symbol route
- `src/features/trading/ticker-header.tsx`: removed `py-2 border-b border-border mb-2` from wrapper div → `flex items-center gap-6 h-full` to fit flush inside `h-12` header
- `src/routes/symbol/-trading-layout.tsx`: removed `<TickerHeader>` JSX and import; removed `MOCK_BASE_BTC`/`MOCK_CHANGE_PCT` from mock-data imports

## Testing

Run `pnpm test` — all existing tests pass. No new tests added; behaviour is visual/routing.

## Notes

`useRouterState({ select: (s) => s.location.pathname })` is the idiomatic TanStack Router pattern for reading current route in a non-route component (the root layout). Avoids prop drilling through `<Outlet>`.
