### PR TITLE
refactor(terminal): rename Trading* identifiers to Terminal*

### DIFF
--- a/src/features/trades/recent-trades-table.tsx
+++ b/src/features/trades/recent-trades-table.tsx
@@ -1,8 +1,8 @@
-import type { TradingLayoutTrade } from "@/lib/mock-data";
+import type { TerminalTrade } from "@/lib/mock-data";
 import { cn } from "@/lib/utils";
 
 interface RecentTradesTableProps {
-  trades: TradingLayoutTrade[];
+  trades: TerminalTrade[];
 }
 
 const BOT_NAMES: Record<string, string> = { "bot-1": "Grid BTC", "bot-2": "DCA ETH" };

--- a/src/features/trading/data-panel.tsx
+++ b/src/features/trading/data-panel.tsx
@@ -2,13 +2,13 @@ import { useState } from "react";
 import { BotManagerPanel } from "@/features/bots/bot-manager-panel";
 import type { BotInstance, BotStatus } from "@/features/bots/types";
 import { RecentTradesTable } from "@/features/trades/recent-trades-table";
-import type { TradingLayoutTrade } from "@/lib/mock-data";
+import type { TerminalTrade } from "@/lib/mock-data";
 import { cn } from "@/lib/utils";
 import { Tab, TabList } from "@/ui/tabs";
 
 interface DataPanelProps {
   bots: BotInstance[];
-  trades: TradingLayoutTrade[];
+  trades: TerminalTrade[];
   onBotStatusChange: (id: string, status: BotStatus) => void;
   className?: string;
 }

--- a/src/features/trading/trading-grid.tsx
+++ b/src/features/trading/trading-grid.tsx
@@ -17,8 +17,8 @@ export type RGLEventCallback = (
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
-type TradingGridProps = ComponentProps<typeof ResponsiveGridLayout>;
+type TerminalGridProps = ComponentProps<typeof ResponsiveGridLayout>;
 
-export default function TradingGrid(props: TradingGridProps) {
+export default function TerminalGrid(props: TerminalGridProps) {
   return <ResponsiveGridLayout {...props} />;
 }

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -108,7 +108,7 @@ export const MOCK_PORTFOLIO_STATE = {
 };
 
 // ── Trades ───────────────────────────────────────────────────
-export interface TradingLayoutTrade {
+export interface TerminalTrade {
   time: string;
   price: number;
   qty: number;
@@ -118,7 +118,7 @@ export interface TradingLayoutTrade {
   botId?: string;
 }
 
-export const MOCK_TRADING_TRADES: TradingLayoutTrade[] = [
+export const MOCK_TERMINAL_TRADES: TerminalTrade[] = [
   {
     time: "14:32:07",
     price: 67843.5,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -3,7 +3,7 @@ import { Toaster, toast } from "sonner";
 import { ThemeDropdown } from "@/features/theme/theme-dropdown";
 import { TickerHeader } from "@/features/trading/ticker-header";
 import { MOCK_BASE_BTC, MOCK_CHANGE_PCT } from "@/lib/mock-data";
-import { useTradingStore } from "@/stores/trading-store";
+import { useTerminalStore } from "@/stores/terminal-store";
 import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
 import { LiveIndicator } from "@/ui/live-indicator";
@@ -16,8 +16,8 @@ export const Route = createRootRoute({
 function RootComponent() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isSymbolRoute = pathname.startsWith("/symbol/");
-  const totalBalance = useTradingStore((s) => s.portfolioSummary.totalBalance);
-  const dailyProfitPct = useTradingStore((s) => s.portfolioSummary.dailyProfitPct);
+  const totalBalance = useTerminalStore((s) => s.portfolioSummary.totalBalance);
+  const dailyProfitPct = useTerminalStore((s) => s.portfolioSummary.dailyProfitPct);
 
   return (
     <ErrorBoundary

--- a/src/routes/symbol/$symbol.tsx
+++ b/src/routes/symbol/$symbol.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { ErrorBoundary } from "@/ui/error-boundary";
 
-import { TradingLayout } from "./-trading-layout";
+import { TerminalLayout } from "./-trading-layout";
 
 export const Route = createFileRoute("/symbol/$symbol" as never)({
   component: RouteComponent,
@@ -12,7 +12,7 @@ function RouteComponent() {
   return (
     <ErrorBoundary>
       <title>{symbol} | Flow</title>
-      <TradingLayout symbol={symbol} />
+      <TerminalLayout symbol={symbol} />
     </ErrorBoundary>
   );
 }

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -10,21 +10,21 @@ import { PortfolioSummaryWidget } from "@/features/trading/portfolio-summary-wid
 import {
   MOCK_ORDER_BOOK_STATE,
   MOCK_PORTFOLIO_SUMMARY,
-  MOCK_TRADING_TRADES,
+  MOCK_TERMINAL_TRADES,
 } from "@/lib/mock-data";
-import { useTradingStore } from "@/stores/trading-store";
+import { useTerminalStore } from "@/stores/terminal-store";
 import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
 import { Panel } from "@/ui/panel";
-import { BREAKPOINTS, COLS, useTradingLayout } from "./-use-trading-layout";
+import { BREAKPOINTS, COLS, useTerminalLayout } from "./-use-trading-layout";
 
-const TradingGrid = lazy(() => import("@/features/trading/trading-grid"));
+const TerminalGrid = lazy(() => import("@/features/trading/trading-grid"));
 
-interface TradingLayoutProps {
+interface TerminalLayoutProps {
   symbol: string;
 }
 
-export function TradingLayout({ symbol }: TradingLayoutProps) {
+export function TerminalLayout({ symbol }: TerminalLayoutProps) {
   const [orderSubmitting, setOrderSubmitting] = useState(false);
   const {
     layouts,
@@ -34,9 +34,9 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
     onResizeStop,
     onDragStart,
     onResizeStart,
-  } = useTradingLayout();
-  const bots = useTradingStore((s) => s.bots);
-  const setBotStatus = useTradingStore((s) => s.setBotStatus);
+  } = useTerminalLayout();
+  const bots = useTerminalStore((s) => s.bots);
+  const setBotStatus = useTerminalStore((s) => s.setBotStatus);
   const [activeTimeframe, setActiveTimeframe] = useState("15m");
 
   const handleOrderSubmit = async (data: OrderFormData) => {
@@ -92,7 +92,7 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
             </div>
           }
         >
-          <TradingGrid
+          <TerminalGrid
             className="layout"
             layouts={layouts}
             breakpoints={BREAKPOINTS}
@@ -153,12 +153,12 @@ export function TradingLayout({ symbol }: TradingLayoutProps) {
               <ErrorBoundary>
                 <DataPanel
                   bots={bots}
-                  trades={MOCK_TRADING_TRADES}
+                  trades={MOCK_TERMINAL_TRADES}
                   onBotStatusChange={(id, s) => setBotStatus(id, s)}
                 />
               </ErrorBoundary>
             </div>
-          </TradingGrid>
+          </TerminalGrid>
         </Suspense>
       </div>
     </ErrorBoundary>

--- a/src/routes/symbol/-use-trading-layout.ts
+++ b/src/routes/symbol/-use-trading-layout.ts
@@ -116,7 +116,7 @@ function loadLayouts(): ResponsiveLayouts<string> {
 // Hook
 // ---------------------------------------------------------------------------
 
-export interface UseTradingLayoutReturn {
+export interface UseTerminalLayoutReturn {
   layouts: ResponsiveLayouts<string>;
   rowHeight: number;
   onBreakpointChange: (bp: string) => void;
@@ -126,7 +126,7 @@ export interface UseTradingLayoutReturn {
   onResizeStart: () => void;
 }
 
-export function useTradingLayout(): UseTradingLayoutReturn {
+export function useTerminalLayout(): UseTerminalLayoutReturn {
   const [layouts, setLayouts] = useState<ResponsiveLayouts<string>>(loadLayouts);
 
   const windowHeight = useSyncExternalStore(

--- a/src/stores/terminal-store.ts
+++ b/src/stores/terminal-store.ts
@@ -7,7 +7,7 @@ import {
   MOCK_PORTFOLIO_SUMMARY,
 } from "@/lib/mock-data";
 
-interface TradingState {
+interface TerminalState {
   orderBook: typeof MOCK_ORDER_BOOK_STATE;
   portfolio: typeof MOCK_PORTFOLIO_STATE;
   portfolioSummary: typeof MOCK_PORTFOLIO_SUMMARY;
@@ -15,7 +15,7 @@ interface TradingState {
   setBotStatus: (id: string, status: BotInstance["status"]) => void;
 }
 
-export const useTradingStore = create<TradingState>((set) => ({
+export const useTerminalStore = create<TerminalState>((set) => ({
   orderBook: MOCK_ORDER_BOOK_STATE,
   portfolio: MOCK_PORTFOLIO_STATE,
   portfolioSummary: MOCK_PORTFOLIO_SUMMARY,


### PR DESCRIPTION
## Summary

Phase 3 of the Flow rebrand: renames all `Trading*` TypeScript identifiers to `Terminal*`. "Terminal" is the semantic descriptor chosen (Option A) — it accurately describes the trading terminal UI without embedding the product brand name in code identifiers.

Closes #87

## Acceptance Criteria

- [x] `pnpm typecheck` passes with zero errors
- [x] `pnpm test` passes — 254 tests pass, 1 skipped
- [x] No `useTradingStore`, `TradingLayout`, `TradingGrid`, `TradingLayoutTrade` remaining in `src/`
- [x] All imports updated to reference `terminal-store`
- [x] Generic occurrences of "trading" in comments/strings are NOT renamed
- [x] All route files written via Python atomic read-modify-write

## Changes

| Before | After | File(s) |
|--------|-------|---------|
| `trading-store.ts` | `terminal-store.ts` | `src/stores/` |
| `useTradingStore` | `useTerminalStore` | `terminal-store.ts`, `__root.tsx`, `-trading-layout.tsx` |
| `TradingState` | `TerminalState` | `terminal-store.ts` |
| `TradingLayout` | `TerminalLayout` | `-trading-layout.tsx`, `$symbol.tsx` |
| `TradingLayoutProps` | `TerminalLayoutProps` | `-trading-layout.tsx` |
| `TradingGrid` | `TerminalGrid` | `trading-grid.tsx`, `-trading-layout.tsx` |
| `TradingGridProps` | `TerminalGridProps` | `trading-grid.tsx` |
| `TradingLayoutTrade` | `TerminalTrade` | `mock-data.ts`, `data-panel.tsx`, `recent-trades-table.tsx` |
| `MOCK_TRADING_TRADES` | `MOCK_TERMINAL_TRADES` | `mock-data.ts`, `-trading-layout.tsx` |
| `useTradingLayout` | `useTerminalLayout` | `-use-trading-layout.ts`, `-trading-layout.tsx` |
| `UseTradingLayoutReturn` | `UseTerminalLayoutReturn` | `-use-trading-layout.ts` |

## Testing

- `pnpm typecheck`: 0 errors ✅
- `pnpm test --run`: 254 passed, 1 skipped ✅
- Grep for leftover identifiers: empty (no matches) ✅

## Notes

`src/features/trading/` folder and route filenames (`-trading-layout.tsx`, `-use-trading-layout.ts`) are intentionally unchanged — "trading" there is the domain concept, not the brand. All route files were modified via Python atomic read-modify-write to avoid TanStack Router Vite plugin file-watching issues.