### PR TITLE
fix(data-panel): My Trades shows user fills + Activity tab isolation

### DIFF
--- a/src/features/trades/my-trades-feed.tsx
+++ b/src/features/trades/my-trades-feed.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/lib/utils";
+import type { SimulatedFill } from "@/stores/terminal-store";
+
+interface MyTradesFeedProps {
+  fills: SimulatedFill[];
+}
+
+function formatTime(ts: number): string {
+  const d = new Date(ts);
+  return [d.getHours(), d.getMinutes(), d.getSeconds()]
+    .map((n) => String(n).padStart(2, "0"))
+    .join(":");
+}
+
+export function MyTradesFeed({ fills }: MyTradesFeedProps) {
+  if (fills.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-16 text-xs text-muted-foreground font-mono">
+        No fills yet — place an order to see your trades here.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-y-auto">
+      <table className="w-full text-xs font-mono tabular-nums">
+        <thead className="sticky top-0 bg-card border-b border-border">
+          <tr className="text-muted-foreground text-left">
+            {(["Time", "Price", "Qty", "Side"] as const).map((h, i) => (
+              <th key={h} className={cn("px-3 py-1.5 font-medium", i >= 1 && "text-right")}>
+                {h}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {fills.map((f) => {
+            const isBuy = f.side === "buy";
+            const color = isBuy ? "text-trading-bid" : "text-trading-ask";
+            return (
+              <tr key={f.id} className="border-b border-border/40 hover:bg-muted/30 transition-colors">
+                <td className="px-3 py-1 text-muted-foreground">{formatTime(f.time)}</td>
+                <td className={cn("px-3 py-1 text-right", color)}>
+                  {parseFloat(f.price).toFixed(2)}
+                </td>
+                <td className="px-3 py-1 text-right text-muted-foreground">
+                  {parseFloat(f.quantity).toFixed(4)}
+                </td>
+                <td className={cn("px-3 py-1 text-right uppercase font-medium", color)}>
+                  {f.side}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/features/trading/data-panel.tsx
+++ b/src/features/trading/data-panel.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState } from "react";
+import { Activity, type ReactNode, useState } from "react";
 import { BotManagerPanel } from "@/features/bots/bot-manager-panel";
 import type { BotInstance, BotStatus } from "@/features/bots/types";
 import { cn } from "@/lib/utils";
@@ -46,8 +46,12 @@ export function DataPanel({ bots, TradesFeedSlot, onBotStatusChange, className }
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto">
-        {activeTab === "trades" && TradesFeedSlot}
-        {activeTab === "bots" && <BotManagerPanel bots={bots} onStatusChange={onBotStatusChange} />}
+        <Activity mode={activeTab === "trades" ? "visible" : "hidden"}>
+          {TradesFeedSlot}
+        </Activity>
+        <Activity mode={activeTab === "bots" ? "visible" : "hidden"}>
+          <BotManagerPanel bots={bots} onStatusChange={onBotStatusChange} />
+        </Activity>
       </div>
     </div>
   );

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -6,12 +6,12 @@ import { useOrderBookViewState } from "@/features/order-book/use-order-book-data
 import type { OrderFormData } from "@/features/order-entry/order-form";
 import { OrderForm } from "@/features/order-entry/order-form";
 import { MarketTradesFeed } from "@/features/trades/market-trades-feed";
-import { TradesFeed } from "@/features/trades/trades-feed";
+import { MyTradesFeed } from "@/features/trades/my-trades-feed";
 import { DataPanel } from "@/features/trading/data-panel";
 import { PortfolioSummaryWidget } from "@/features/trading/portfolio-summary-widget";
 
 import { MOCK_PORTFOLIO_SUMMARY } from "@/lib/mock-data";
-import { useBaseAsset, useTrades } from "@/stores/market-data";
+import { useBaseAsset } from "@/stores/market-data";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
@@ -60,9 +60,10 @@ function MarketTradesPanel() {
   );
 }
 
-function TradesFeedPanel() {
-  const liveTrades = useTrades();
-  return <TradesFeed trades={liveTrades} />;
+/** Leaf — owns fills subscription; never causes TerminalLayout to re-render. */
+function MyTradesPanel() {
+  const fills = useTerminalStore((s) => s.fills);
+  return <MyTradesFeed fills={fills} />;
 }
 
 export function TerminalLayout({ symbol, tab = "book", levels = 20 }: TerminalLayoutProps) {
@@ -203,7 +204,7 @@ export function TerminalLayout({ symbol, tab = "book", levels = 20 }: TerminalLa
               <ErrorBoundary>
                 <DataPanel
                   bots={bots}
-                  TradesFeedSlot={<TradesFeedPanel />}
+                  TradesFeedSlot={<MyTradesPanel />}
                   onBotStatusChange={(id, s) => setBotStatus(id, s)}
                 />
               </ErrorBoundary>

--- a/src/stores/terminal-store.ts
+++ b/src/stores/terminal-store.ts
@@ -7,12 +7,23 @@ import {
   MOCK_PORTFOLIO_SUMMARY,
 } from "@/lib/mock-data";
 
+export interface SimulatedFill {
+  id: string;
+  symbol: string;
+  side: "buy" | "sell";
+  price: string;
+  quantity: string;
+  time: number;
+}
+
 interface TerminalState {
   orderBook: typeof MOCK_ORDER_BOOK_STATE;
   portfolio: typeof MOCK_PORTFOLIO_STATE;
   portfolioSummary: typeof MOCK_PORTFOLIO_SUMMARY;
   bots: BotInstance[];
+  fills: SimulatedFill[];
   setBotStatus: (id: string, status: BotInstance["status"]) => void;
+  addFill: (fill: SimulatedFill) => void;
 }
 
 export const useTerminalStore = create<TerminalState>((set) => ({
@@ -20,8 +31,11 @@ export const useTerminalStore = create<TerminalState>((set) => ({
   portfolio: MOCK_PORTFOLIO_STATE,
   portfolioSummary: MOCK_PORTFOLIO_SUMMARY,
   bots: MOCK_BOTS,
+  fills: [],
   setBotStatus: (id, status) =>
     set((state) => ({
       bots: state.bots.map((b) => (b.id === id ? { ...b, status } : b)),
     })),
+  addFill: (fill) =>
+    set((state) => ({ fills: [fill, ...state.fills].slice(0, 200) })),
 }));


### PR DESCRIPTION
## Summary

Fixes #108

### 1. My Trades data source corrected
`TradesFeedPanel` was reading from `useTrades()` (WebSocket market stream). Replaced with `MyTradesPanel` reading `useTerminalStore(s => s.fills)` — user-placed simulated fills only.

Empty state shown until issue #97 (LocalFillEngine) populates the fills array.

### 2. `<Activity>` tab isolation
`DataPanel` now wraps each tab in `<Activity mode>` instead of `&&` conditional rendering:
- Hidden tabs defer effects and rendering — zero render budget consumed
- State preserved on tab switch (no unmount/remount lag)
- Matches `react-realtime` skill AC for hidden tab isolation

### Changes
| File | Change |
|------|--------|
| `src/stores/terminal-store.ts` | Added `SimulatedFill` type, `fills[]`, `addFill()` |
| `src/features/trades/my-trades-feed.tsx` | New component for user fills |
| `src/features/trading/data-panel.tsx` | `&&` → `<Activity>` for both tabs |
| `src/routes/symbol/-trading-layout.tsx` | `MyTradesPanel` leaf replaces `TradesFeedPanel` |

### Test
321 passing, typecheck clean.