### PR TITLE
feat(order-book): price grouping + view mode toggle

### DIFF
--- a/src/domain/market-data/book-grouping.ts
+++ b/src/domain/market-data/book-grouping.ts
@@ -1,0 +1,55 @@
+/**
+ * Price grouping — pure domain logic.
+ * Aggregates raw order book levels into price buckets of a given tick size.
+ * Zero dependencies on React, Zustand, or browser APIs.
+ */
+
+/**
+ * Bucket a price into the nearest tick boundary (floor).
+ * Uses integer rounding to avoid floating-point drift.
+ *
+ * @example bucketPrice(100.15, 0.1) → 100.1
+ */
+function bucketPrice(price: number, tickSize: number): number {
+  const inv = Math.round(1 / tickSize);
+  return Math.floor(price * inv) / inv;
+}
+
+/**
+ * Group raw Map<price, qty> entries into aggregated tick-size buckets.
+ * Returns sorted [bucketPrice, totalQty] pairs.
+ *
+ * @param map      Raw price → quantity map from the order book snapshot
+ * @param tickSize Price bucket width (e.g. 0.1, 1, 10)
+ * @param sortAsc  true = lowest price first (asks), false = highest first (bids)
+ */
+export function groupLevels(
+  map: Map<string, string>,
+  tickSize: number,
+  sortAsc: boolean,
+): [number, number][] {
+  const buckets = new Map<number, number>();
+
+  for (const [p, q] of map.entries()) {
+    const qty = parseFloat(q);
+    if (qty <= 0) continue;
+    const price = parseFloat(p);
+    const bucket = bucketPrice(price, tickSize);
+    buckets.set(bucket, (buckets.get(bucket) ?? 0) + qty);
+  }
+
+  const entries = [...buckets.entries()];
+  entries.sort((a, b) => (sortAsc ? a[0] - b[0] : b[0] - a[0]));
+  return entries;
+}
+
+/**
+ * Derive the set of available grouping options for a symbol given its
+ * price precision (decimal places).
+ *
+ * @example groupingOptions(2) → [0.1, 1, 10, 100]   (BTCUSDT)
+ * @example groupingOptions(4) → [0.001, 0.01, 0.1, 1] (smaller pairs)
+ */
+export function groupingOptions(pricePrecision: number): number[] {
+  return [1, 2, 3, 4].map((i) => parseFloat((10 ** (i - pricePrecision)).toPrecision(8)));
+}

--- a/src/features/order-book/use-order-book-data.ts
+++ b/src/features/order-book/use-order-book-data.ts
@@ -1,3 +1,4 @@
+import { groupLevels } from "@/domain/market-data/book-grouping";
 import { useMarketDataStore } from "@/stores/market-data";
 import type { OrderBookState } from "./order-book";
 import type { PriceLevel } from "./order-book-row";
@@ -6,15 +7,25 @@ import type { PriceLevel } from "./order-book-row";
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function computeLevels(map: Map<string, string>, limit: number, sortAsc: boolean): PriceLevel[] {
-  const entries: [number, number][] = [];
-  for (const [p, q] of map.entries()) {
-    const qty = parseFloat(q);
-    if (qty > 0) entries.push([parseFloat(p), qty]);
-  }
-  entries.sort((a, b) => (sortAsc ? a[0] - b[0] : b[0] - a[0]));
-  const sliced = entries.slice(0, limit);
+function computeLevels(
+  map: Map<string, string>,
+  limit: number,
+  sortAsc: boolean,
+  tickSize?: number,
+): PriceLevel[] {
+  const raw: [number, number][] = tickSize
+    ? groupLevels(map, tickSize, sortAsc)
+    : (() => {
+        const entries: [number, number][] = [];
+        for (const [p, q] of map.entries()) {
+          const qty = parseFloat(q);
+          if (qty > 0) entries.push([parseFloat(p), qty]);
+        }
+        entries.sort((a, b) => (sortAsc ? a[0] - b[0] : b[0] - a[0]));
+        return entries;
+      })();
 
+  const sliced = raw.slice(0, limit);
   const maxQty = sliced.reduce((m, [, q]) => (q > m ? q : m), 0);
   let cumTotal = 0;
   return sliced.map(([price, qty]) => {
@@ -38,7 +49,7 @@ function computeLevels(map: Map<string, string>, limit: number, sortAsc: boolean
  * from object-returning selectors (Zustand Object.is equality).
  * Returns null while waiting for the initial order book snapshot (loading state).
  */
-export function useOrderBookViewState(levels = 20): OrderBookState | null {
+export function useOrderBookViewState(levels = 20, tickSize?: number): OrderBookState | null {
   // Split subscriptions so each re-renders only when its specific slice changes
   const orderBook = useMarketDataStore((s) => s.orderBook);
   const trades = useMarketDataStore((s) => s.trades);
@@ -47,8 +58,8 @@ export function useOrderBookViewState(levels = 20): OrderBookState | null {
   if (!orderBook) return null;
 
   // Bids sorted highest-first (desc); asks sorted lowest-first (asc)
-  const bids = computeLevels(orderBook.bids, levels, false);
-  const asks = computeLevels(orderBook.asks, levels, true);
+  const bids = computeLevels(orderBook.bids, levels, false, tickSize);
+  const asks = computeLevels(orderBook.asks, levels, true, tickSize);
 
   const bestBid = bids[0]?.price ?? 0;
   // asks sorted asc → index 0 = lowest price = best ask

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useState } from "react";
 import { toast } from "sonner";
+import { groupingOptions } from "@/domain/market-data/book-grouping";
 import { CandleChart } from "@/features/chart/candle-chart";
 import { OrderBook } from "@/features/order-book/order-book";
 import { useOrderBookViewState } from "@/features/order-book/use-order-book-data";
@@ -9,9 +10,8 @@ import { MarketTradesFeed } from "@/features/trades/market-trades-feed";
 import { MyTradesFeed } from "@/features/trades/my-trades-feed";
 import { DataPanel } from "@/features/trading/data-panel";
 import { PortfolioSummaryWidget } from "@/features/trading/portfolio-summary-widget";
-
 import { MOCK_PORTFOLIO_SUMMARY } from "@/lib/mock-data";
-import { useBaseAsset } from "@/stores/market-data";
+import { useBaseAsset, usePricePrecision, useTrades } from "@/stores/market-data";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
@@ -29,20 +29,83 @@ interface TerminalLayoutProps {
 // Leaf components — own their own store subscriptions so TerminalLayout
 // never re-renders due to high-frequency market data updates.
 
+type ViewMode = "both" | "bids" | "asks";
+
 interface OrderBookPanelProps {
   levels: number;
 }
 
 function OrderBookPanel({ levels }: OrderBookPanelProps) {
-  const orderBookState = useOrderBookViewState(levels);
-  return orderBookState ? (
-    <OrderBook state={orderBookState} />
-  ) : (
-    <div className="flex flex-col gap-1 p-2" data-testid="order-book-skeleton">
-      {Array.from({ length: 12 }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
-        <div key={i} className="h-5 rounded bg-muted animate-pulse" />
-      ))}
+  const pricePrecision = usePricePrecision();
+  const options = groupingOptions(pricePrecision);
+  const [tickSize, setTickSize] = useState<number>(options[0] ?? 1);
+  const [viewMode, setViewMode] = useState<ViewMode>("both");
+
+  const raw = useOrderBookViewState(levels, tickSize);
+
+  const orderBookState = raw
+    ? {
+        ...raw,
+        bids: viewMode === "asks" ? [] : raw.bids,
+        asks: viewMode === "bids" ? [] : raw.asks,
+      }
+    : null;
+
+  const viewModes: { mode: ViewMode; label: string; title: string }[] = [
+    { mode: "both", label: "⇅", title: "Bids & Asks" },
+    { mode: "asks", label: "↑", title: "Asks only" },
+    { mode: "bids", label: "↓", title: "Bids only" },
+  ];
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      {/* Panel controls row */}
+      <div className="flex items-center justify-between px-2 py-0.5 border-b border-border shrink-0">
+        {/* View mode toggle */}
+        <div className="flex items-center gap-0.5">
+          {viewModes.map(({ mode, label, title }) => (
+            <button
+              key={mode}
+              type="button"
+              title={title}
+              onClick={() => setViewMode(mode)}
+              className={[
+                "w-6 h-5 flex items-center justify-center rounded text-[11px] font-mono",
+                "transition-colors cursor-pointer",
+                viewMode === mode
+                  ? "bg-primary/15 text-primary"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted",
+              ].join(" ")}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        {/* Price grouping selector */}
+        <select
+          value={tickSize}
+          onChange={(e) => setTickSize(parseFloat(e.target.value))}
+          className="text-[11px] font-mono bg-transparent text-muted-foreground hover:text-foreground border border-border rounded px-1 py-0.5 cursor-pointer outline-none focus:border-primary"
+        >
+          {options.map((opt) => (
+            <option key={opt} value={opt}>
+              {opt}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Book content */}
+      {orderBookState ? (
+        <OrderBook state={orderBookState} />
+      ) : (
+        <div className="flex flex-col gap-1 p-2" data-testid="order-book-skeleton">
+          {Array.from({ length: 12 }).map((_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: static skeleton
+            <div key={i} className="h-5 rounded bg-muted animate-pulse" />
+          ))}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #109

Adds Binance-style order book controls:
- **Price grouping dropdown** aggregates levels into tick-size buckets (0.1, 1, 10, 100 for BTCUSDT)
- **View mode toggle** — Bids+Asks / Asks-only / Bids-only

## Changes

### Domain (pure)
- `book-grouping.ts`: `groupLevels()` + `groupingOptions()`

### Application
- `useOrderBookViewState(levels, tickSize?)` — delegates to groupLevels when tickSize set

### Presentation
- `OrderBookPanel`: header row with view-mode buttons + grouping select; default tick from `usePricePrecision()`

## Architecture
Dependency direction maintained. `groupLevels` is zero-dep domain logic. DS tokens used throughout.

## Tests
321 passing, typecheck clean