### PR TITLE
perf(tab): fix blank screen and frozen UI on tab return

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,11 @@
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 
-const router = createRouter({ routeTree });
+const router = createRouter({
+  routeTree,
+  defaultStaleTime: Infinity,
+  defaultGcTime: Infinity,
+});
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/src/stores/market-data.ts
+++ b/src/stores/market-data.ts
@@ -34,7 +34,11 @@ interface MarketDataActions {
 // ---------------------------------------------------------------------------
 // RAF-batched depth update queue (AC-7)
 // Updates are queued and flushed at most once per animation frame.
+// When the tab is backgrounded, RAF pauses but the WS keeps pushing.
+// MAX_PENDING caps the queue so tab-return doesn't block the main thread.
 // ---------------------------------------------------------------------------
+
+const MAX_PENDING = 10;
 
 let pendingUpdates: NormalizedDepthUpdate[] = [];
 let rafHandle: number | null = null;
@@ -60,6 +64,18 @@ function scheduleDepthUpdate(update: NormalizedDepthUpdate): void {
   if (rafHandle === null) {
     rafHandle = requestAnimationFrame(flushDepthUpdates);
   }
+}
+
+// Drain stale queued updates when the tab becomes visible again.
+// Without this, a backgrounded WS floods pendingUpdates[] (RAF is paused
+// while hidden) and the synchronous flush on tab-return blocks the main thread.
+if (typeof document !== "undefined") {
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible" && pendingUpdates.length > MAX_PENDING) {
+      // Keep only the most recent MAX_PENDING updates — older ones are stale.
+      pendingUpdates = pendingUpdates.slice(-MAX_PENDING);
+    }
+  });
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes two independent root causes behind the blank screen and frozen UI reported in #113 when returning to the dashboard tab after it's been backgrounded.

---

### Root cause 1 — Blank screen (2–5s) `src/App.tsx`

`createRouter()` had no `defaultStaleTime`, which defaults to `0`. Every tab focus event triggers a navigation, causing loaders to re-run: `teardown()` → `initMarketData()` → async Binance snapshot fetch. The UI is blank for the entire async round-trip (~2s).

**Fix:** `defaultStaleTime: Infinity` + `defaultGcTime: Infinity` — data is considered fresh for the lifetime of the session. Explicit refetches (symbol switches) still work correctly.

---

### Root cause 2 — Frozen UI (600ms+ main thread block) `src/stores/market-data.ts`

RAF is paused/throttled when the tab is hidden, but the WebSocket keeps receiving depth updates. `scheduleDepthUpdate` kept pushing to `pendingUpdates[]` with no upper bound. After ~30s in background: 1500+ queued entries. On tab return, `flushDepthUpdates` processes the entire array in a synchronous loop — blocking the main thread for 600ms+.

**Fix:** A `visibilitychange` listener caps `pendingUpdates` to `MAX_PENDING = 10` (most-recent entries) when the tab becomes visible. The stale intermediate states are discarded — only the latest snapshot of book depth is needed.

---

## Files changed

| File | Change |
|------|--------|
| `src/App.tsx` | `defaultStaleTime: Infinity`, `defaultGcTime: Infinity` |
| `src/stores/market-data.ts` | `MAX_PENDING = 10` + `visibilitychange` drain guard |

## Checklist
- [x] `pnpm lint:fix` — 0 errors
- [x] `pnpm typecheck` — exits 0
- [x] `pnpm build` — exits 0
- [x] Tests — 321 passed

Closes #113