### PR TITLE
refactor(root): extract PortfolioWidget to eliminate root re-render cascade

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -19,11 +19,26 @@ function LiveIndicatorConnected({ className }: { className?: string }) {
   return <LiveIndicator status={status} className={className} />;
 }
 
+function PortfolioWidget() {
+  const totalBalance = useTerminalStore((s) => s.portfolioSummary.totalBalance);
+  const dailyProfitPct = useTerminalStore((s) => s.portfolioSummary.dailyProfitPct);
+  return (
+    <Link
+      to="/portfolio"
+      className="flex items-center gap-3 px-3 py-1 rounded border border-border/60 transition-colors hover:border-border text-xs font-mono bg-background"
+    >
+      <span className="tabular-nums font-semibold">
+        ${totalBalance.toLocaleString("en-US", { minimumFractionDigits: 2 })}
+      </span>
+      <span className="tabular-nums text-trading-profit">+{dailyProfitPct}%</span>
+      <span className="text-[10px] text-muted-foreground">Portfolio →</span>
+    </Link>
+  );
+}
+
 function RootComponent() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const isSymbolRoute = pathname.startsWith("/symbol/");
-  const totalBalance = useTerminalStore((s) => s.portfolioSummary.totalBalance);
-  const dailyProfitPct = useTerminalStore((s) => s.portfolioSummary.dailyProfitPct);
   return (
     <ErrorBoundary
       fallback={(error) => (
@@ -50,16 +65,7 @@ function RootComponent() {
             </Link>
             {isSymbolRoute && <TickerHeader price={MOCK_BASE_BTC} changePct={MOCK_CHANGE_PCT} />}
             <div className="flex-1" />
-            <Link
-              to="/portfolio"
-              className="flex items-center gap-3 px-3 py-1 rounded border border-border/60 transition-colors hover:border-border text-xs font-mono bg-background"
-            >
-              <span className="tabular-nums font-semibold">
-                ${totalBalance.toLocaleString("en-US", { minimumFractionDigits: 2 })}
-              </span>
-              <span className="tabular-nums text-trading-profit">+{dailyProfitPct}%</span>
-              <span className="text-[10px] text-muted-foreground">Portfolio →</span>
-            </Link>
+            <PortfolioWidget />
             <div className="w-px h-5 bg-border mx-1" />
             <ThemeDropdown />
             <LiveIndicatorConnected className="ml-1" />


### PR DESCRIPTION
## Summary

Extracts `PortfolioWidget` from `RootComponent` — the last store subscription left in the root component after #104 fixed `LiveIndicatorConnected`.

## Root cause

`RootComponent` subscribed directly to `useTerminalStore` for `totalBalance` and `dailyProfitPct`. Every simulated fill triggered a `RootComponent` re-render → `Outlet` → trading layout cascade.

React Compiler memoizes child components, so the cascade is mostly contained — but store subscriptions in root are an architectural smell: root is the widest possible re-render boundary, and any future change that breaks memoization would bring back the full cascade.

## Fix

Extracted a `PortfolioWidget` leaf component that owns both store subscriptions — same pattern as the existing `LiveIndicatorConnected`. `RootComponent` now has **zero store subscriptions** (only `useRouterState`, which is stable between navigations).

## Files changed

| File | Change |
|------|--------|
| `src/routes/__root.tsx` | Extract `PortfolioWidget` leaf; `RootComponent` has zero store subscriptions |

## Checklist
- [x] `pnpm lint:fix` — 0 errors
- [x] `pnpm typecheck` — exits 0
- [x] `pnpm build` — exits 0
- [x] Tests — 321 passed

Closes #105