### PR TITLE
perf(order-book): prevent CLS micro-stutters on live data updates

### DIFF
--- a/src/features/order-book/order-book-row.test.tsx
+++ b/src/features/order-book/order-book-row.test.tsx
@@ -39,6 +39,7 @@ describe("OrderBookRow", () => {
       "tabular-nums",
       "font-mono",
       "text-xs",
+      "overflow-x-hidden",
     );
   });
 

--- a/src/features/order-book/order-book-row.tsx
+++ b/src/features/order-book/order-book-row.tsx
@@ -15,14 +15,18 @@ export function OrderBookRow({ level, side }: OrderBookRowProps) {
 
   return (
     <div
-      className={cn("relative grid grid-cols-3 gap-2 tabular-nums font-mono text-xs px-2 py-0.5")}
+      className={cn(
+        "relative grid grid-cols-3 gap-2 tabular-nums font-mono text-xs px-2 py-0.5 overflow-x-hidden",
+      )}
     >
       <DepthBar percent={level.percent} side={side} />
-      <div className={cn("relative z-10", textColor)}>{level.price.toFixed(pricePrecision)}</div>
-      <div className="relative z-10 text-right text-muted-foreground">
+      <div className={cn("relative z-10 min-w-0 overflow-hidden", textColor)}>
+        {level.price.toFixed(pricePrecision)}
+      </div>
+      <div className="relative z-10 min-w-0 overflow-hidden text-right text-muted-foreground">
         {level.quantity.toFixed(qtyPrecision)}
       </div>
-      <div className="relative z-10 text-right text-muted-foreground">
+      <div className="relative z-10 min-w-0 overflow-hidden text-right text-muted-foreground">
         {level.total.toFixed(qtyPrecision)}
       </div>
     </div>

--- a/src/features/order-book/order-book.test.tsx
+++ b/src/features/order-book/order-book.test.tsx
@@ -33,13 +33,13 @@ describe("OrderBook", () => {
   it("asks container scrolls independently", () => {
     render(<OrderBook state={MOCK_ORDER_BOOK_STATE} />);
     const asksContainer = screen.getByTestId("asks-container");
-    expect(asksContainer).toHaveClass("overflow-y-auto", "flex-1");
+    expect(asksContainer).toHaveClass("overflow-y-scroll", "flex-1");
   });
 
   it("bids container scrolls independently", () => {
     render(<OrderBook state={MOCK_ORDER_BOOK_STATE} />);
     const bidsContainer = screen.getByTestId("bids-container");
-    expect(bidsContainer).toHaveClass("overflow-y-auto", "flex-1");
+    expect(bidsContainer).toHaveClass("overflow-y-scroll", "flex-1");
   });
 
   it("spread bar is not inside a scrollable container", () => {

--- a/src/features/order-book/order-book.tsx
+++ b/src/features/order-book/order-book.tsx
@@ -24,7 +24,7 @@ function OrderBookAsks() {
   return (
     <div
       data-testid="asks-container"
-      className="flex-1 min-h-0 overflow-y-auto flex flex-col justify-end"
+      className="flex-1 min-h-0 overflow-y-scroll flex flex-col justify-end"
     >
       <AskTable levels={state.asks} />
     </div>
@@ -34,7 +34,7 @@ function OrderBookAsks() {
 function OrderBookBids() {
   const state = useOrderBookContext();
   return (
-    <div data-testid="bids-container" className="flex-1 min-h-0 overflow-y-auto">
+    <div data-testid="bids-container" className="flex-1 min-h-0 overflow-y-scroll">
       <BidTable levels={state.bids} />
     </div>
   );


### PR DESCRIPTION
## Summary

Eliminates layout shift micro-stutters (16 events/session per trace) in the live order book.

## Root Cause

The order book uses a **CSS Grid** (`grid-cols-3`) layout per row. With the default browser behavior:

1. **Grid cells without `min-w-0`** can expand beyond their `1fr` allotment when content overflows, forcing a full row relayout on every WebSocket update
2. **`overflow-y-auto`** on asks/bids containers causes a scrollbar gutter to appear/disappear as rows populate, shifting the container width and triggering CLS on all child rows simultaneously

## Changes

| File | Change |
|------|--------|
| `order-book-row.tsx` | Added `overflow-x-hidden` on row container; added `min-w-0 overflow-hidden` on each cell |
| `order-book.tsx` | Changed asks/bids scroll containers from `overflow-y-auto` → `overflow-y-scroll` (always-visible gutter) |
| `order-book-row.test.tsx` | Updated layout class assertion |
| `order-book.test.tsx` | Updated scroll class assertions |

## Acceptance Criteria

- [x] AC-1: Order book row cells constrained to their grid column (no overflow expansion)
- [x] AC-2: Grid columns have stable widths regardless of content length (`min-w-0` + `overflow-hidden`)
- [x] AC-3: Scrollbar gutter always reserved (`overflow-y-scroll`) — no width shift on row count change
- [x] AC-4: No visual regression — numbers remain right-aligned, truncate within their column

## Test results

```
Tests  334 passed | 1 skipped (335)
```

Closes #118