### PR TITLE
fix(landing): mark all features done; replace inline styles with Tailwind

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
+import { cn } from "@/lib/utils";
 import { ErrorBoundary } from "@/ui/error-boundary";
 
 // biome-ignore lint/suspicious/noExplicitAny: TanStack Router codegen pending
@@ -11,10 +12,10 @@ const STATUS = [
   { label: "Order book UI", note: "Bid/ask depth, spread, tick animation", done: true },
   { label: "Order entry form", note: "Market + limit, Zod validation", done: true },
   { label: "Portfolio components", note: "Balances, positions, PnL", done: true },
-  { label: "WebSocket data layer", note: "Binance depth + trades streams", done: false },
-  { label: "Symbol routing", note: "Typed params, URL search state", done: false },
-  { label: "Depth chart", note: "Lightweight Charts integration", done: false },
-  { label: "Simulated order fills", note: "Paper trading against live prices", done: false },
+  { label: "WebSocket data layer", note: "Binance depth + trades streams", done: true },
+  { label: "Symbol routing", note: "Typed params, URL search state", done: true },
+  { label: "Depth chart", note: "Lightweight Charts integration", done: true },
+  { label: "Simulated order fills", note: "Paper trading against live prices", done: true },
 ] as const;
 
 const STACK = [
@@ -34,26 +35,15 @@ export default function LandingPage() {
         {/* Hero */}
         <section className="flex flex-col gap-6">
           <div className="flex items-center gap-3">
-            <span
-              className="w-2 h-2 rounded-full animate-pulse"
-              style={{ backgroundColor: "var(--trading-connected)" }}
-            />
-            <span
-              className="font-mono text-xs tracking-widest uppercase"
-              style={{ color: "var(--trading-connected)" }}
-            >
+            <span className="w-2 h-2 rounded-full animate-pulse bg-trading-connected" />
+            <span className="font-mono text-xs tracking-widest uppercase text-trading-connected">
               Build in public · Active development
             </span>
           </div>
 
-          <h1
-            className="font-brand text-5xl font-bold leading-tight"
-            style={{ color: "var(--primary)" }}
-          >
-            Flow
-          </h1>
+          <h1 className="font-brand text-5xl font-bold leading-tight text-primary">Flow</h1>
 
-          <p className="text-lg max-w-xl" style={{ color: "var(--color-muted-foreground)" }}>
+          <p className="text-lg max-w-xl text-muted-foreground">
             A real-time crypto trading terminal simulator. Live Binance market data, 60fps
             rendering, zero manual memoization. Portfolio project demonstrating React 19.2 + Vite 8
             + WebSocket data handling.
@@ -65,90 +55,72 @@ export default function LandingPage() {
               to={"/symbol/$symbol" as any}
               // biome-ignore lint/suspicious/noExplicitAny: TanStack Router codegen pending
               params={{ symbol: "BTCUSDT" } as any}
-              className="px-5 py-2.5 rounded font-mono text-sm font-medium transition-colors"
-              style={{
-                backgroundColor: "var(--primary)",
-                color: "var(--primary-foreground)",
-              }}
+              className="px-5 py-2.5 rounded font-mono text-sm font-medium transition-colors bg-primary text-primary-foreground"
             >
               Open Terminal →
             </Link>
             <Link
               // biome-ignore lint/suspicious/noExplicitAny: TanStack Router codegen pending
               to={"/design-system" as any}
-              className="px-5 py-2.5 rounded font-mono text-sm font-medium border transition-colors"
-              style={{
-                borderColor: "var(--primary)",
-                color: "var(--primary)",
-              }}
+              className="px-5 py-2.5 rounded font-mono text-sm font-medium border transition-colors border-primary text-primary"
             >
               Design System
             </Link>
           </div>
         </section>
 
-        <div className="h-px" style={{ backgroundColor: "var(--color-border)" }} />
+        <div className="h-px bg-border" />
 
         {/* Build status */}
         <section className="flex flex-col gap-6">
-          <h2
-            className="font-brand text-sm uppercase tracking-widest"
-            style={{ color: "var(--color-muted-foreground)" }}
-          >
+          <h2 className="font-brand text-sm uppercase tracking-widest text-muted-foreground">
             Build Status
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {STATUS.map(({ label, note, done }) => (
               <div
                 key={label}
-                className="flex items-start gap-3 px-4 py-3 rounded border"
-                style={{
-                  borderColor: done ? "var(--trading-bid-muted)" : "var(--color-border)",
-                  backgroundColor: done ? "var(--trading-bid-muted)" + "18" : "transparent",
-                }}
+                className={cn(
+                  "flex items-start gap-3 px-4 py-3 rounded border",
+                  done
+                    ? "border-trading-bid-muted bg-trading-bid-muted/10"
+                    : `
+                    border-border bg-transparent
+                  `,
+                )}
               >
                 <span
-                  className="mt-0.5 font-mono text-xs shrink-0"
-                  style={{
-                    color: done ? "var(--trading-profit)" : "var(--color-muted-foreground)",
-                  }}
+                  className={cn(
+                    "mt-0.5 font-mono text-xs shrink-0",
+                    done ? "text-trading-profit" : "text-muted-foreground",
+                  )}
                 >
                   {done ? "✓" : "○"}
                 </span>
                 <div>
                   <p className="text-sm font-medium">{label}</p>
-                  <p className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
-                    {note}
-                  </p>
+                  <p className="text-xs text-muted-foreground">{note}</p>
                 </div>
               </div>
             ))}
           </div>
         </section>
 
-        <div className="h-px" style={{ backgroundColor: "var(--color-border)" }} />
+        <div className="h-px bg-border" />
 
         {/* Stack */}
         <section className="flex flex-col gap-6">
-          <h2
-            className="font-brand text-sm uppercase tracking-widest"
-            style={{ color: "var(--color-muted-foreground)" }}
-          >
+          <h2 className="font-brand text-sm uppercase tracking-widest text-muted-foreground">
             Stack
           </h2>
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             {STACK.map(([name, detail]) => (
               <div
                 key={name}
-                className="flex flex-col gap-0.5 px-4 py-3 rounded border"
-                style={{ borderColor: "var(--color-border)" }}
+                className="flex flex-col gap-0.5 px-4 py-3 rounded border border-border"
               >
-                <span className="font-mono text-sm font-medium" style={{ color: "var(--primary)" }}>
-                  {name}
-                </span>
-                <span className="text-xs" style={{ color: "var(--color-muted-foreground)" }}>
-                  {detail}
-                </span>
+                <span className="font-mono text-sm font-medium text-primary">{name}</span>
+                <span className="text-xs text-muted-foreground">{detail}</span>
               </div>
             ))}
           </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -84,9 +84,7 @@ export default function LandingPage() {
                   "flex items-start gap-3 px-4 py-3 rounded border",
                   done
                     ? "border-trading-bid-muted bg-trading-bid-muted/10"
-                    : `
-                    border-border bg-transparent
-                  `,
+                    : `border-border bg-transparent`,
                 )}
               >
                 <span


### PR DESCRIPTION
## Summary
Fixes two landing page audit findings before this goes in front of recruiters.

## Changes

### STATUS array (Closes #134)
Four features were incorrectly marked `done: false` despite being fully implemented:
- ✅ WebSocket data layer
- ✅ Symbol routing
- ✅ Depth chart (Lightweight Charts integration)
- ✅ Simulated order fills

### Inline styles (Closes #137)
All 16 `style={{}}` inline color/background instances replaced with semantic Tailwind utility classes:
- `text-primary`, `text-muted-foreground`, `text-trading-connected`, `text-trading-profit`
- `bg-primary`, `bg-border`, `bg-trading-connected`, `bg-trading-bid-muted/10`
- `border-primary`, `border-border`, `border-trading-bid-muted`

Also fixed a pre-existing CSS bug: `"var(--trading-bid-muted)" + "18"` was concatenating `"18"` to an oklch value, creating invalid CSS. Now uses `bg-trading-bid-muted/10`.

## Test plan
- 343 tests pass
- `pnpm typecheck` exits 0
- `pnpm lint:fix` exits 0

---

Closes #134
Closes #137