### PR TITLE
feat(ticker): wire live price, OHLV, and tick direction from @miniTicker stream; fix portfolio widget

### DIFF
--- a/src/domain/market-data/MarketDataSource.ts
+++ b/src/domain/market-data/MarketDataSource.ts
@@ -1,4 +1,9 @@
-import type { NormalizedDepthUpdate, NormalizedSnapshot, NormalizedTrade } from "./normalized";
+import type {
+  NormalizedDepthUpdate,
+  NormalizedSnapshot,
+  NormalizedTicker,
+  NormalizedTrade,
+} from "./normalized";
 import type { ConnectionStatus } from "./types";
 
 /**
@@ -16,4 +21,5 @@ export interface MarketDataSource {
   getSnapshot(symbol: string): Promise<NormalizedSnapshot>;
   onDepthUpdate(cb: (update: NormalizedDepthUpdate) => void): void;
   onTrade(cb: (trade: NormalizedTrade) => void): void;
+  onTicker(cb: (ticker: NormalizedTicker) => void): void;
 }

--- a/src/domain/market-data/normalized.ts
+++ b/src/domain/market-data/normalized.ts
@@ -20,3 +20,12 @@ export interface NormalizedTrade {
   time: number;
   isBuyerMaker: boolean;
 }
+
+/** 24-hour rolling ticker stats from the @miniTicker stream. */
+export interface NormalizedTicker {
+  lastPrice: string;
+  openPrice: string;
+  highPrice: string;
+  lowPrice: string;
+  volume: string;
+}

--- a/src/features/trading/ticker-header.tsx
+++ b/src/features/trading/ticker-header.tsx
@@ -1,44 +1,67 @@
 import { cn } from "@/lib/utils";
+import { useLastPrice, usePriceChangePct, useTicker } from "@/stores/market-data";
 import { SymbolSelector } from "@/ui/symbol-selector";
 
-interface TickerHeaderProps {
-  price: number;
-  changePct: number;
-}
+export function TickerHeader() {
+  const lastPrice = useLastPrice();
+  const changePct = usePriceChangePct();
+  const ticker = useTicker();
+  const isPositive = (changePct ?? 0) >= 0;
 
-const OHLV = [
-  { label: "O", value: "66,420.00" },
-  { label: "H", value: "68,240.00" },
-  { label: "L", value: "65,920.00" },
-  { label: "Vol", value: "24,831 BTC" },
-];
+  const ohlv = ticker
+    ? [
+        {
+          label: "O",
+          value: Number(ticker.openPrice).toLocaleString("en-US", { minimumFractionDigits: 2 }),
+        },
+        {
+          label: "H",
+          value: Number(ticker.highPrice).toLocaleString("en-US", { minimumFractionDigits: 2 }),
+        },
+        {
+          label: "L",
+          value: Number(ticker.lowPrice).toLocaleString("en-US", { minimumFractionDigits: 2 }),
+        },
+        {
+          label: "Vol",
+          value: `${Number(ticker.volume).toLocaleString("en-US", { maximumFractionDigits: 0 })} BTC`,
+        },
+      ]
+    : null;
 
-export function TickerHeader({ price, changePct }: TickerHeaderProps) {
-  const isPositive = changePct >= 0;
   return (
     <div className="flex items-center gap-6 h-full">
       <SymbolSelector triggerClassName="font-mono text-base font-bold text-primary hover:text-primary/80" />
-      <span className="font-mono text-xl tabular-nums font-semibold text-trading-tick-up">
-        {price.toLocaleString("en-US", { minimumFractionDigits: 2 })}
-      </span>
       <span
         className={cn(
-          "font-mono text-xs tabular-nums px-1.5 py-0.5 rounded",
-          isPositive
-            ? "text-trading-profit bg-trading-bid-muted"
-            : "text-trading-loss bg-trading-ask-muted",
+          "font-mono text-xl tabular-nums font-semibold",
+          isPositive ? "text-trading-tick-up" : "text-trading-tick-down",
         )}
       >
-        {isPositive ? "+" : ""}
-        {Math.abs(changePct).toFixed(2)}%
+        {lastPrice != null ? lastPrice.toLocaleString("en-US", { minimumFractionDigits: 2 }) : "—"}
       </span>
-      <div className="flex gap-5 text-xs font-mono tabular-nums text-muted-foreground ml-2">
-        {OHLV.map(({ label, value }) => (
-          <span key={label}>
-            {label} <span className="text-foreground">{value}</span>
-          </span>
-        ))}
-      </div>
+      {changePct != null && (
+        <span
+          className={cn(
+            "font-mono text-xs tabular-nums px-1.5 py-0.5 rounded",
+            isPositive
+              ? "text-trading-profit bg-trading-bid-muted"
+              : "text-trading-loss bg-trading-ask-muted",
+          )}
+        >
+          {isPositive ? "+" : ""}
+          {Math.abs(changePct).toFixed(2)}%
+        </span>
+      )}
+      {ohlv && (
+        <div className="flex gap-5 text-xs font-mono tabular-nums text-muted-foreground ml-2">
+          {ohlv.map(({ label, value }) => (
+            <span key={label}>
+              {label} <span className="text-foreground">{value}</span>
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/infra/binance/BinanceDataSource.ts
+++ b/src/infra/binance/BinanceDataSource.ts
@@ -2,6 +2,7 @@ import type { MarketDataSource } from "@/domain/market-data/MarketDataSource";
 import type {
   NormalizedDepthUpdate,
   NormalizedSnapshot,
+  NormalizedTicker,
   NormalizedTrade,
 } from "@/domain/market-data/normalized";
 import type { ConnectionStatus } from "@/domain/market-data/types";
@@ -40,6 +41,7 @@ export class BinanceDataSource implements MarketDataSource {
   private statusCallbacks: Array<(s: ConnectionStatus) => void> = [];
   private depthCallbacks: Array<(u: NormalizedDepthUpdate) => void> = [];
   private tradeCallbacks: Array<(t: NormalizedTrade) => void> = [];
+  private tickerCallbacks: Array<(t: NormalizedTicker) => void> = [];
 
   /** Depth events received before the snapshot was applied. */
   private depthBuffer: NormalizedDepthUpdate[] = [];
@@ -115,9 +117,13 @@ export class BinanceDataSource implements MarketDataSource {
     this.tradeCallbacks.push(cb);
   }
 
+  onTicker(cb: (ticker: NormalizedTicker) => void): void {
+    this.tickerCallbacks.push(cb);
+  }
+
   private connectStreams(symbol: string): void {
     const s = symbol.toLowerCase();
-    this.wsClient.connect([`${s}@depth`, `${s}@aggTrade`]);
+    this.wsClient.connect([`${s}@depth`, `${s}@aggTrade`, `${s}@miniTicker`]);
     this.emitStatus("reconnecting");
   }
 
@@ -150,6 +156,14 @@ export class BinanceDataSource implements MarketDataSource {
         isBuyerMaker: msg.m,
       };
       this.emitTrade(trade);
+    } else if (msg.e === "24hrMiniTicker") {
+      this.emitTicker({
+        lastPrice: msg.c,
+        openPrice: msg.o,
+        highPrice: msg.h,
+        lowPrice: msg.l,
+        volume: msg.v,
+      });
     }
   }
 
@@ -170,5 +184,9 @@ export class BinanceDataSource implements MarketDataSource {
 
   private emitTrade(trade: NormalizedTrade): void {
     for (const cb of this.tradeCallbacks) cb(trade);
+  }
+
+  private emitTicker(ticker: NormalizedTicker): void {
+    for (const cb of this.tickerCallbacks) cb(ticker);
   }
 }

--- a/src/infra/binance/schemas.ts
+++ b/src/infra/binance/schemas.ts
@@ -37,9 +37,24 @@ export const AggTradeEventSchema = z.object({
 });
 export type AggTradeEventMsg = z.infer<typeof AggTradeEventSchema>;
 
+/** Binance WebSocket 24hr mini-ticker event (@miniTicker stream). */
+export const MiniTickerEventSchema = z.object({
+  e: z.literal("24hrMiniTicker"),
+  E: z.number(), // event time
+  s: z.string(), // symbol
+  c: z.string(), // last (close) price
+  o: z.string(), // open price
+  h: z.string(), // high price
+  l: z.string(), // low price
+  v: z.string(), // base asset volume
+  q: z.string(), // quote asset volume
+});
+export type MiniTickerEventMsg = z.infer<typeof MiniTickerEventSchema>;
+
 /** Discriminated union for all stream messages this app consumes. */
 export const StreamMessageSchema = z.discriminatedUnion("e", [
   DepthUpdateSchema,
   AggTradeEventSchema,
+  MiniTickerEventSchema,
 ]);
 export type StreamMessage = z.infer<typeof StreamMessageSchema>;

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -2,9 +2,8 @@ import { createRootRoute, Link, Outlet, useRouterState } from "@tanstack/react-r
 import { Toaster, toast } from "sonner";
 import { ThemeDropdown } from "@/features/theme/theme-dropdown";
 import { TickerHeader } from "@/features/trading/ticker-header";
-import { MOCK_BASE_BTC, MOCK_CHANGE_PCT } from "@/lib/mock-data";
 import { useConnectionStatus } from "@/stores/market-data";
-import { useTerminalStore } from "@/stores/terminal-store";
+import { useBalance } from "@/stores/portfolio";
 import { Button } from "@/ui/button";
 import { ErrorBoundary } from "@/ui/error-boundary";
 import { LiveIndicator } from "@/ui/live-indicator";
@@ -20,18 +19,17 @@ function LiveIndicatorConnected({ className }: { className?: string }) {
 }
 
 function PortfolioWidget() {
-  const totalBalance = useTerminalStore((s) => s.portfolioSummary.totalBalance);
-  const dailyProfitPct = useTerminalStore((s) => s.portfolioSummary.dailyProfitPct);
+  const usdtBalance = useBalance("USDT");
+  const balance = Number(usdtBalance);
   return (
     <Link
       to="/portfolio"
       className="flex items-center gap-3 px-3 py-1 rounded border border-border/60 transition-colors hover:border-border text-xs font-mono bg-background"
     >
       <span className="tabular-nums font-semibold">
-        ${totalBalance.toLocaleString("en-US", { minimumFractionDigits: 2 })}
+        ${balance.toLocaleString("en-US", { minimumFractionDigits: 2 })}
       </span>
-      <span className="tabular-nums text-trading-profit">+{dailyProfitPct}%</span>
-      <span className="text-[10px] text-muted-foreground">Portfolio →</span>
+      <span className="text-[10px] text-muted-foreground">USDT · Portfolio →</span>
     </Link>
   );
 }
@@ -63,7 +61,7 @@ function RootComponent() {
               <Logo className="w-6 h-6" />
               {!isSymbolRoute && <span className="ml-2">Flow</span>}
             </Link>
-            {isSymbolRoute && <TickerHeader price={MOCK_BASE_BTC} changePct={MOCK_CHANGE_PCT} />}
+            {isSymbolRoute && <TickerHeader />}
             <div className="flex-1" />
             <PortfolioWidget />
             <div className="w-px h-5 bg-border mx-1" />

--- a/src/stores/market-data.test.ts
+++ b/src/stores/market-data.test.ts
@@ -4,6 +4,7 @@ import type { MarketDataSource } from "@/domain/market-data/MarketDataSource";
 import type {
   NormalizedDepthUpdate,
   NormalizedSnapshot,
+  NormalizedTicker,
   NormalizedTrade,
 } from "@/domain/market-data/normalized";
 import type { ConnectionStatus } from "@/domain/market-data/types";
@@ -21,6 +22,7 @@ function createMockSource() {
   let statusCb: ((s: ConnectionStatus) => void) | null = null;
   let depthCb: ((u: NormalizedDepthUpdate) => void) | null = null;
   let tradeCb: ((t: NormalizedTrade) => void) | null = null;
+  let tickerCb: ((t: NormalizedTicker) => void) | null = null;
 
   const source: MarketDataSource = {
     connect: vi.fn(),
@@ -33,6 +35,9 @@ function createMockSource() {
     }),
     onTrade: vi.fn((cb) => {
       tradeCb = cb;
+    }),
+    onTicker: vi.fn((cb) => {
+      tickerCb = cb;
     }),
     getSnapshot: vi.fn(),
   };
@@ -47,6 +52,9 @@ function createMockSource() {
     },
     emitTrade: (t: NormalizedTrade) => {
       tradeCb?.(t);
+    },
+    emitTicker: (t: NormalizedTicker) => {
+      tickerCb?.(t);
     },
   };
 }

--- a/src/stores/market-data.ts
+++ b/src/stores/market-data.ts
@@ -4,6 +4,7 @@ import type { MarketDataSource } from "@/domain/market-data/MarketDataSource";
 import type {
   NormalizedDepthUpdate,
   NormalizedSnapshot,
+  NormalizedTicker,
   NormalizedTrade,
 } from "@/domain/market-data/normalized";
 import type { ConnectionStatus, OrderBook } from "@/domain/market-data/types";
@@ -17,6 +18,7 @@ import type { SymbolInfo } from "@/lib/symbols";
 interface MarketDataState {
   orderBook: OrderBook | null;
   trades: NormalizedTrade[];
+  ticker: NormalizedTicker | null;
   connectionStatus: ConnectionStatus;
   symbol: string | null;
   symbolInfo: SymbolInfo | null;
@@ -85,6 +87,7 @@ if (typeof document !== "undefined") {
 export const useMarketDataStore = create<MarketDataState & MarketDataActions>((set) => ({
   orderBook: null,
   trades: [],
+  ticker: null,
   connectionStatus: "disconnected",
   symbol: null,
   symbolInfo: null,
@@ -107,6 +110,10 @@ export const useMarketDataStore = create<MarketDataState & MarketDataActions>((s
       set((state) => ({
         trades: [trade, ...state.trades].slice(0, RING_BUFFER_SIZE),
       }));
+    });
+
+    source.onTicker((ticker) => {
+      set({ ticker });
     });
 
     set({ symbol, connectionStatus: "reconnecting" });
@@ -132,6 +139,7 @@ export const useMarketDataStore = create<MarketDataState & MarketDataActions>((s
     set({
       orderBook: null,
       trades: [],
+      ticker: null,
       connectionStatus: "disconnected",
       symbol: null,
       symbolInfo: null,
@@ -201,5 +209,26 @@ export function useBestBid(): string | null {
     const book = s.orderBook;
     if (!book || book.bids.size === 0) return null;
     return String(Math.max(...[...book.bids.keys()].map(Number)));
+  });
+}
+
+/** 24-hour mini-ticker snapshot, or null before the first @miniTicker event. */
+export function useTicker(): NormalizedTicker | null {
+  return useMarketDataStore((s) => s.ticker);
+}
+
+/** Last traded price as a number, or null before ticker arrives. */
+export function useLastPrice(): number | null {
+  return useMarketDataStore((s) => (s.ticker ? Number(s.ticker.lastPrice) : null));
+}
+
+/** 24h price change percentage (computed from open/close), or null before ticker arrives. */
+export function usePriceChangePct(): number | null {
+  return useMarketDataStore((s) => {
+    if (!s.ticker) return null;
+    const open = Number(s.ticker.openPrice);
+    const close = Number(s.ticker.lastPrice);
+    if (open === 0) return null;
+    return ((close - open) / open) * 100;
   });
 }


### PR DESCRIPTION
## Summary
Wires the header ticker and portfolio widget to real live data, replacing all mock constants.

## Changes

### @miniTicker stream (Closes #135)
- **Domain**: Added `NormalizedTicker` type (`lastPrice`, `openPrice`, `highPrice`, `lowPrice`, `volume`)
- **Port**: Added `onTicker(cb)` to `MarketDataSource` interface
- **Infra**: Added `MiniTickerEventSchema` for Binance `24hrMiniTicker` events; subscribed `@miniTicker` stream alongside `@depth` and `@aggTrade`
- **Store**: Added `ticker` state field; wired `onTicker` handler; added `useTicker()`, `useLastPrice()`, `usePriceChangePct()` selectors
- **Component**: `TickerHeader` now self-subscribes (no props); shows live price, ±% badge with correct direction color (`text-trading-tick-up`/`text-trading-tick-down`), live OHLV row. Shows `—` placeholder before first event.

### Portfolio widget (Closes #136)
- `PortfolioWidget` in `__root.tsx` now reads from `useBalance("USDT")` (real portfolio store) instead of `useTerminalStore` mock
- Removed hardcoded $125,342.00 — balance now reflects actual paper trading state
- Removed mock `dailyProfitPct` (no historical PnL tracking; removed the misleading +X% display)

### Cleanup
- Removed `MOCK_BASE_BTC` and `MOCK_CHANGE_PCT` imports from `__root.tsx`
- Updated `market-data.test.ts` mock source to implement new `onTicker` method

## Test plan
- 343 tests pass
- `pnpm typecheck` exits 0
- `pnpm build` exits 0
- `pnpm lint:fix` exits 0

---

Closes #135
Closes #136