### PR TITLE
fix(ds): badge bg-muted, DataPanel default tab, Qty column header

### DIFF
--- a/src/features/trades/market-trades-feed.tsx
+++ b/src/features/trades/market-trades-feed.tsx
@@ -2,7 +2,6 @@ import type { NormalizedTrade } from "@/domain/market-data/normalized";
 import { cn } from "@/lib/utils";
 
 interface MarketTradesFeedProps {
-  symbol: string;
   trades: NormalizedTrade[];
 }
 
@@ -13,7 +12,7 @@ function formatTime(ts: number): string {
     .join(":");
 }
 
-export function MarketTradesFeed({ symbol, trades }: MarketTradesFeedProps) {
+export function MarketTradesFeed({ trades }: MarketTradesFeedProps) {
   if (trades.length === 0) {
     return (
       <div className="flex items-center justify-center h-10 text-xs text-muted-foreground font-mono">
@@ -27,7 +26,7 @@ export function MarketTradesFeed({ symbol, trades }: MarketTradesFeedProps) {
       <thead className="sticky top-0 bg-card border-b border-border">
         <tr className="text-muted-foreground text-left">
           <th className="px-2 py-1 font-medium text-left">Price</th>
-          <th className="px-2 py-1 font-medium text-right">{`Amount (${symbol})`}</th>
+          <th className="px-2 py-1 font-medium text-right">Qty</th>
           <th className="px-2 py-1 font-medium text-right">Time</th>
         </tr>
       </thead>

--- a/src/features/trading/data-panel.tsx
+++ b/src/features/trading/data-panel.tsx
@@ -23,7 +23,7 @@ type TabValue = (typeof TABS)[number]["value"];
 
 /** Self-contained panel — owns its own chrome matching Panel header height/typography. */
 export function DataPanel({ bots, TradesFeedSlot, onBotStatusChange, className }: DataPanelProps) {
-  const [activeTab, setActiveTab] = useState<TabValue>("bots");
+  const [activeTab, setActiveTab] = useState<TabValue>("trades");
 
   return (
     <div

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -9,7 +9,7 @@ import { MyTradesFeed } from "@/features/trades/my-trades-feed";
 import { DataPanel } from "@/features/trading/data-panel";
 import { PortfolioSummaryWidget } from "@/features/trading/portfolio-summary-widget";
 import { MOCK_PORTFOLIO_SUMMARY } from "@/lib/mock-data";
-import { useBaseAsset, useConnectionStatus, useTrades } from "@/stores/market-data";
+import { useConnectionStatus, useTrades } from "@/stores/market-data";
 import { useFilledOrders, usePortfolioStore } from "@/stores/portfolio";
 import { useTerminalStore } from "@/stores/terminal-store";
 import { Button } from "@/ui/button";
@@ -26,12 +26,11 @@ interface TerminalLayoutProps {
 
 /** Leaf — owns useTrades() subscription; never causes TerminalLayout to re-render. */
 function MarketTradesPanel() {
-  const base = useBaseAsset();
   const trades = useTrades();
   return (
     <div className="flex flex-col h-full min-h-0">
       <div className="flex-1 min-h-0 overflow-y-auto">
-        <MarketTradesFeed symbol={base} trades={trades} />
+        <MarketTradesFeed trades={trades} />
       </div>
     </div>
   );

--- a/src/ui/badge.test.tsx
+++ b/src/ui/badge.test.tsx
@@ -17,7 +17,7 @@ describe("Badge", () => {
   it("applies default variant (pill) classes when no variant specified", () => {
     render(<Badge>Default</Badge>);
     const el = screen.getByText("Default");
-    expect(el).toHaveClass("bg-ds-gray-800", "text-muted-foreground");
+    expect(el).toHaveClass("bg-muted", "text-muted-foreground");
   });
 
   it("applies active variant classes", () => {
@@ -65,7 +65,7 @@ describe("Badge", () => {
   it("applies stat variant classes (different sizing: text-xs)", () => {
     render(<Badge variant="stat">123</Badge>);
     const el = screen.getByText("123");
-    expect(el).toHaveClass("text-xs", "bg-ds-gray-800", "px-2", "py-1");
+    expect(el).toHaveClass("text-xs", "bg-muted", "px-2", "py-1");
   });
 
   it("merges custom className with variant classes", () => {

--- a/src/ui/badge.tsx
+++ b/src/ui/badge.tsx
@@ -9,9 +9,9 @@ const badgeVariants = cva("inline-flex items-center rounded font-mono transition
       // Muted/upcoming status
       muted: "text-[10px] text-muted-foreground border border-border px-1.5 py-0.5",
       // Tag chip (symbol, category)
-      pill: "text-[10px] bg-ds-gray-800 text-muted-foreground px-1.5 py-0.5",
+      pill: "text-[10px] bg-muted text-muted-foreground px-1.5 py-0.5",
       // Numeric stat with dark bg
-      stat: "text-xs bg-ds-gray-800 px-2 py-1",
+      stat: "text-xs bg-muted px-2 py-1",
       // Trading side badges
       buy: "text-[10px] px-1.5 py-0.5 text-trading-bid border border-trading-bid/30",
       sell: "text-[10px] px-1.5 py-0.5 text-trading-ask border border-trading-ask/30",


### PR DESCRIPTION
## Summary
Three independent 1–2 line fixes from the design audit.

### Badge DS token (Closes #138)
`bg-ds-gray-800` is a raw palette token — forbidden per CLAUDE.md. Replaced with `bg-muted` (semantic token) in both `pill` and `stat` variants. Tests updated.

### DataPanel default tab (Closes #139)
Default active tab changed from `"bots"` to `"trades"`. After placing an order the user naturally expects to see My Trades, not the Bots tab.

### Trades column header (Closes #145)
`Amount (BTC)` header renamed to `Qty`. The symbol is already shown in the panel title — the parenthetical was redundant chrome. The `symbol` prop is now unused and has been removed from `MarketTradesFeedProps` and its call site.

## Test plan
- 343 tests pass
- `pnpm typecheck` exits 0
- `pnpm lint:fix` exits 0

---

Closes #138
Closes #139
Closes #145