### PR TITLE
fix(panel): conditional cursor-move, title contrast + rich empty states

### DIFF
--- a/src/features/order-book/order-book-panel.tsx
+++ b/src/features/order-book/order-book-panel.tsx
@@ -16,7 +16,7 @@ export function OrderBookPanel() {
   const BookView = BOOK_VIEW[viewMode];
 
   return (
-    <Panel title="Order Book">
+    <Panel title="Order Book" draggable>
       <Panel.Content noScroll>
         <BookControls.Root>
           <BookControls.ViewToggle value={viewMode} onChange={setViewMode} />

--- a/src/features/order-entry/open-orders.tsx
+++ b/src/features/order-entry/open-orders.tsx
@@ -1,3 +1,4 @@
+import { ClipboardList } from "lucide-react";
 import { useOpenOrders, usePortfolioStore } from "@/stores/portfolio";
 import { Button } from "@/ui/button";
 
@@ -7,8 +8,12 @@ export function OpenOrders() {
 
   if (orders.length === 0) {
     return (
-      <div className="flex flex-col h-full justify-center">
-        <p className="text-xs text-muted-foreground text-center py-4 font-mono">No open orders</p>
+      <div className="flex flex-col items-center justify-center h-full gap-2 py-6 text-center">
+        <ClipboardList className="w-6 h-6 text-muted-foreground/40" strokeWidth={1.5} />
+        <p className="text-xs text-muted-foreground font-mono">No open orders</p>
+        <p className="text-[10px] text-muted-foreground/60 font-mono">
+          Place a limit order to see it here
+        </p>
       </div>
     );
   }

--- a/src/features/trades/my-trades-feed.tsx
+++ b/src/features/trades/my-trades-feed.tsx
@@ -1,3 +1,4 @@
+import { Activity } from "lucide-react";
 import type { Order } from "@/domain/trading/types";
 import { cn } from "@/lib/utils";
 
@@ -15,10 +16,12 @@ function formatTime(ts: number): string {
 export function MyTradesFeed({ orders }: MyTradesFeedProps) {
   if (orders.length === 0) {
     return (
-      <div className="flex flex-col h-full justify-center">
-        <div className="flex items-center justify-center h-16 text-xs text-muted-foreground font-mono">
-          No fills yet — place an order to see your trades here.
-        </div>
+      <div className="flex flex-col items-center justify-center h-full gap-2 py-6 text-center">
+        <Activity className="w-6 h-6 text-muted-foreground/40" strokeWidth={1.5} />
+        <p className="text-xs text-muted-foreground font-mono">No fills yet</p>
+        <p className="text-[10px] text-muted-foreground/60 font-mono">
+          Place an order to see your trades here
+        </p>
       </div>
     );
   }

--- a/src/routes/portfolio.tsx
+++ b/src/routes/portfolio.tsx
@@ -12,8 +12,8 @@ function RouteComponent() {
   const filledOrders = useFilledOrders();
   const openOrders = useOpenOrders();
 
-  const usdt = Number(balances["USDT"] ?? 0);
-  const btc = Number(balances["BTC"] ?? 0);
+  const usdt = Number(balances.USDT ?? 0);
+  const btc = Number(balances.BTC ?? 0);
 
   return (
     <ErrorBoundary>

--- a/src/routes/symbol/-trading-layout.tsx
+++ b/src/routes/symbol/-trading-layout.tsx
@@ -88,7 +88,7 @@ function OrderPanel({ symbol }: { symbol: string }) {
   };
 
   return (
-    <Panel title="Place Order">
+    <Panel title="Place Order" draggable>
       <Panel.Content>
         <div className="p-3">
           <OrderForm
@@ -168,7 +168,7 @@ export function TerminalLayout({ symbol, tab = "book" }: TerminalLayoutProps) {
               </ErrorBoundary>
             </div>
             <div key="chart">
-              <Panel title="Price Chart">
+              <Panel title="Price Chart" draggable>
                 <Panel.Header extra={timeframeTabs} />
                 <Panel.Content noScroll>
                   <div className="flex-1 p-2 min-h-0">
@@ -184,7 +184,7 @@ export function TerminalLayout({ symbol, tab = "book" }: TerminalLayoutProps) {
             </div>
             <div key="portfolio">
               <ErrorBoundary>
-                <Panel title="Portfolio">
+                <Panel title="Portfolio" draggable>
                   <Panel.Content noScroll>
                     <PortfolioSummaryWidget {...MOCK_PORTFOLIO_SUMMARY} botPnl={botPnl} />
                   </Panel.Content>
@@ -193,7 +193,7 @@ export function TerminalLayout({ symbol, tab = "book" }: TerminalLayoutProps) {
             </div>
             <div key="trades">
               <ErrorBoundary>
-                <Panel title="Market Trades">
+                <Panel title="Market Trades" draggable>
                   <Panel.Content noScroll>
                     <MarketTradesPanel />
                   </Panel.Content>

--- a/src/ui/panel.tsx
+++ b/src/ui/panel.tsx
@@ -58,9 +58,7 @@ export function Panel({ title, children, className, draggable = false }: PanelPr
     >
       <div
         className={cn(
-          `
-        px-3 py-2 border-b border-border shrink-0 flex items-center justify-between gap-2
-      `,
+          `px-3 py-2 border-b border-border shrink-0 flex items-center justify-between gap-2`,
           draggable && `cursor-move`,
         )}
       >

--- a/src/ui/panel.tsx
+++ b/src/ui/panel.tsx
@@ -5,6 +5,7 @@ interface PanelProps {
   title: string;
   children: ReactNode;
   className?: string;
+  draggable?: boolean;
 }
 
 interface PanelHeaderProps {
@@ -36,7 +37,7 @@ function PanelContent({ children, noScroll = false, className }: PanelContentPro
   );
 }
 
-export function Panel({ title, children, className }: PanelProps) {
+export function Panel({ title, children, className, draggable = false }: PanelProps) {
   let extra: ReactNode = null;
   const bodyChildren: ReactNode[] = [];
 
@@ -55,8 +56,15 @@ export function Panel({ title, children, className }: PanelProps) {
         className,
       )}
     >
-      <div className="px-3 py-2 border-b border-border shrink-0 cursor-move flex items-center justify-between gap-2">
-        <h2 className="text-xs font-cypher font-semibold tracking-widest uppercase text-muted-foreground select-none">
+      <div
+        className={cn(
+          `
+        px-3 py-2 border-b border-border shrink-0 flex items-center justify-between gap-2
+      `,
+          draggable && `cursor-move`,
+        )}
+      >
+        <h2 className="text-xs font-cypher font-semibold tracking-widest uppercase text-foreground select-none">
           {title}
         </h2>
         {extra}


### PR DESCRIPTION
## Summary

Three panel polish fixes from the audit:

### #141 — Conditional `cursor-move` on Panel
`cursor-move` was applied unconditionally to every `Panel` header, even in non-draggable contexts (dialogs, sidebars). Now it's gated behind a `draggable` prop (default `false`). All panels inside the react-grid-layout canvas pass `draggable={true}`.

### #142 — Panel title contrast
Panel titles were `text-muted-foreground` — too low contrast for a primary label. Changed to `text-foreground`.

### #143 — Rich empty states with icons
Replaced bare `<p>` text empty states with icon + two-line label/hint pattern:
- **Open Orders**: `ClipboardList` icon + "No open orders" + "Place a limit order to see it here"
- **My Trades**: `Activity` icon + "No fills yet" + "Place an order to see your trades here"

## Files Changed
- `src/ui/panel.tsx` — `draggable` prop + title color
- `src/features/order-book/order-book-panel.tsx` — `draggable`
- `src/routes/symbol/-trading-layout.tsx` — `draggable` on 3 grid panels + OrderPanel
- `src/features/order-entry/open-orders.tsx` — rich empty state
- `src/features/trades/my-trades-feed.tsx` — rich empty state

## Checklist
- [x] `pnpm lint:fix` — clean (1 auto-format fix, 0 errors)
- [x] `pnpm test` — 343 passed
- [x] No inline styles, no raw palette tokens
- [x] Closes #141, #142, #143

---

Closes #141
Closes #142
Closes #143