### PR TITLE
fix(chart-order-book): real-time kline stream and full-row depth bar

### DIFF
--- a/src/domain/market-data/MarketDataSource.ts
+++ b/src/domain/market-data/MarketDataSource.ts
@@ -1,6 +1,7 @@
 import type {
   NormalizedCandle,
   NormalizedDepthUpdate,
+  NormalizedKlineUpdate,
   NormalizedSnapshot,
   NormalizedTicker,
   NormalizedTrade,
@@ -26,4 +27,14 @@ export interface MarketDataSource {
 
   /** Fetch historical OHLCV candles from REST. Returns up to `limit` candles. */
   fetchKlines(symbol: string, interval: string, limit: number): Promise<NormalizedCandle[]>;
+
+  /** Register a callback for live kline updates from the WebSocket stream. */
+  onKlineUpdate(cb: (update: NormalizedKlineUpdate) => void): void;
+
+  /**
+   * Subscribe to the @kline_<interval> WebSocket stream.
+   * Call after fetchKlines() so the interval is known.
+   * Reconnects the combined stream to include the kline sub-stream.
+   */
+  subscribeKlineStream(symbol: string, interval: string): void;
 }

--- a/src/domain/market-data/normalized.ts
+++ b/src/domain/market-data/normalized.ts
@@ -39,3 +39,9 @@ export interface NormalizedCandle {
   close: number;
   volume: number;
 }
+
+/** Live kline tick from the @kline_* WebSocket stream. */
+export interface NormalizedKlineUpdate extends NormalizedCandle {
+  /** true when the candle for this period has closed and a new one begins. */
+  isClosed: boolean;
+}

--- a/src/features/chart/candle-chart.tsx
+++ b/src/features/chart/candle-chart.tsx
@@ -103,9 +103,18 @@ export function CandleChart({ symbol, interval = "15m" }: CandleChartProps) {
     // that would recreate the chart on every state change.
     let prevKlines = initial;
     const unsub = useMarketDataStore.subscribe((state) => {
-      if (state.klines !== prevKlines && state.klines.length > 0) {
-        prevKlines = state.klines;
-        series.setData(state.klines.map(toChartData));
+      if (state.klines === prevKlines) return;
+      const newKlines = state.klines;
+      prevKlines = newKlines;
+      if (newKlines.length === 0) return;
+
+      if (state.klineIsLiveTick) {
+        // Only the last candle changed — use efficient point update, no scroll jump
+        const last = newKlines[newKlines.length - 1];
+        if (last) series.update(toChartData(last));
+      } else {
+        // Full REST load or new candle appended — reset series and fit view
+        series.setData(newKlines.map(toChartData));
         chart.timeScale().fitContent();
       }
     });

--- a/src/features/order-book/order-book-row.test.tsx
+++ b/src/features/order-book/order-book-row.test.tsx
@@ -40,7 +40,6 @@ describe("OrderBookRow", () => {
     const row = container.firstChild as HTMLElement;
     expect(row.tagName).toBe("TR");
     expect(row).toHaveClass(
-      "relative",
       "tabular-nums",
       "font-mono",
       "text-xs",
@@ -84,10 +83,17 @@ describe("OrderBookRow", () => {
     await user.keyboard("{Enter}");
     expect(useUIStore.getState().selectedPrice).toBe(42500.5);
   });
-  it("renders DepthBar component", () => {
+  it("applies depth bar as full-row backgroundImage on bid side", () => {
     const { container } = render(<OrderBookRow level={mockLevel} side="bid" />);
-    const depthBar = container.querySelector("[class*='opacity-15']");
-    expect(depthBar).toBeInTheDocument();
+    const row = container.firstChild as HTMLElement;
+    expect(row.style.backgroundImage).toContain("trading-bid");
+    expect(row.style.backgroundImage).toContain("45%");
+  });
+
+  it("applies depth bar as full-row backgroundImage on ask side", () => {
+    const { container } = render(<OrderBookRow level={mockLevel} side="ask" />);
+    const row = container.firstChild as HTMLElement;
+    expect(row.style.backgroundImage).toContain("trading-ask");
   });
 
   it("formats prices with 2 decimal places", () => {

--- a/src/features/order-book/order-book-row.tsx
+++ b/src/features/order-book/order-book-row.tsx
@@ -1,7 +1,6 @@
 import { cn } from "@/lib/utils";
 import { usePricePrecision, useQtyPrecision } from "@/stores/market-data";
 import { useUIStore } from "@/stores/ui";
-import { DepthBar } from "@/ui/depth-bar";
 import type { PriceLevel } from "./types";
 
 interface OrderBookRowProps {
@@ -14,12 +13,20 @@ export function OrderBookRow({ level, side }: OrderBookRowProps) {
   const qtyPrecision = useQtyPrecision();
   const setSelectedPrice = useUIStore((s) => s.setSelectedPrice);
   const textColor = side === "bid" ? "text-trading-bid" : "text-trading-ask";
+  const depthColor =
+    side === "bid"
+      ? "color-mix(in srgb, var(--trading-bid) 15%, transparent)"
+      : "color-mix(in srgb, var(--trading-ask) 15%, transparent)";
+  const pct = Math.max(0, Math.min(100, level.percent));
 
   const handleSelect = () => setSelectedPrice(level.price);
 
   return (
     <tr
-      className="relative tabular-nums font-mono text-xs cursor-pointer select-none hover:bg-muted overflow-x-hidden"
+      className="tabular-nums font-mono text-xs cursor-pointer select-none hover:bg-muted overflow-x-hidden"
+      style={{
+        backgroundImage: `linear-gradient(to left, ${depthColor} ${pct}%, transparent ${pct}%)`,
+      }}
       onClick={handleSelect}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") handleSelect();
@@ -27,15 +34,13 @@ export function OrderBookRow({ level, side }: OrderBookRowProps) {
       tabIndex={0}
       aria-label={`Select price ${level.price.toFixed(pricePrecision)}`}
     >
-      <td className={cn("relative z-10 px-2 py-0.5 min-w-0 overflow-hidden", textColor)}>
-        {/* DepthBar is absolute-positioned; <tr className="relative"> is its containing block */}
-        <DepthBar percent={level.percent} side={side} />
+      <td className={cn("px-2 py-0.5 min-w-0 overflow-hidden", textColor)}>
         {level.price.toFixed(pricePrecision)}
       </td>
-      <td className="relative z-10 px-2 py-0.5 min-w-0 overflow-hidden text-right text-muted-foreground">
+      <td className="px-2 py-0.5 min-w-0 overflow-hidden text-right text-muted-foreground">
         {level.quantity.toFixed(qtyPrecision)}
       </td>
-      <td className="relative z-10 px-2 py-0.5 min-w-0 overflow-hidden text-right text-muted-foreground">
+      <td className="px-2 py-0.5 min-w-0 overflow-hidden text-right text-muted-foreground">
         {level.total.toFixed(qtyPrecision)}
       </td>
     </tr>

--- a/src/infra/binance/BinanceDataSource.ts
+++ b/src/infra/binance/BinanceDataSource.ts
@@ -2,6 +2,7 @@ import type { MarketDataSource } from "@/domain/market-data/MarketDataSource";
 import type {
   NormalizedCandle,
   NormalizedDepthUpdate,
+  NormalizedKlineUpdate,
   NormalizedSnapshot,
   NormalizedTicker,
   NormalizedTrade,
@@ -43,12 +44,15 @@ export class BinanceDataSource implements MarketDataSource {
   private depthCallbacks: Array<(u: NormalizedDepthUpdate) => void> = [];
   private tradeCallbacks: Array<(t: NormalizedTrade) => void> = [];
   private tickerCallbacks: Array<(t: NormalizedTicker) => void> = [];
+  private klineCallbacks: Array<(u: NormalizedKlineUpdate) => void> = [];
 
   /** Depth events received before the snapshot was applied. */
   private depthBuffer: NormalizedDepthUpdate[] = [];
   /** lastUpdateId from the most recently applied snapshot. null = snapshot not yet applied. */
   private snapshotSeqId: number | null = null;
   private currentSymbol: string | null = null;
+  /** Kline interval subscribed via subscribeKlineStream. null = not yet requested. */
+  private currentKlineInterval: string | null = null;
 
   constructor() {
     this.reconnectManager.onReconnect(() => {
@@ -74,6 +78,7 @@ export class BinanceDataSource implements MarketDataSource {
     this.reconnectManager.reset();
     this.wsClient.close();
     this.currentSymbol = null;
+    this.currentKlineInterval = null;
     this.snapshotSeqId = null;
     this.depthBuffer = [];
   }
@@ -122,6 +127,18 @@ export class BinanceDataSource implements MarketDataSource {
     this.tickerCallbacks.push(cb);
   }
 
+  onKlineUpdate(cb: (update: NormalizedKlineUpdate) => void): void {
+    this.klineCallbacks.push(cb);
+  }
+
+  subscribeKlineStream(symbol: string, interval: string): void {
+    this.currentKlineInterval = interval;
+    // Reconnect combined stream to include the kline sub-stream.
+    // wsClient.connect() closes the old WS without triggering onDisconnect,
+    // so depth buffering and reconnect manager are not disrupted.
+    this.connectStreams(symbol);
+  }
+
   async fetchKlines(symbol: string, interval: string, limit: number): Promise<NormalizedCandle[]> {
     const url = `https://api.binance.com/api/v3/klines?symbol=${symbol.toUpperCase()}&interval=${interval}&limit=${limit}`;
     const res = await fetch(url);
@@ -139,7 +156,11 @@ export class BinanceDataSource implements MarketDataSource {
 
   private connectStreams(symbol: string): void {
     const s = symbol.toLowerCase();
-    this.wsClient.connect([`${s}@depth`, `${s}@aggTrade`, `${s}@miniTicker`]);
+    const streams = [`${s}@depth`, `${s}@aggTrade`, `${s}@miniTicker`];
+    if (this.currentKlineInterval) {
+      streams.push(`${s}@kline_${this.currentKlineInterval}`);
+    }
+    this.wsClient.connect(streams);
     this.emitStatus("reconnecting");
   }
 
@@ -180,6 +201,17 @@ export class BinanceDataSource implements MarketDataSource {
         lowPrice: msg.l,
         volume: msg.v,
       });
+    } else if (msg.e === "kline") {
+      const k = msg.k;
+      this.emitKlineUpdate({
+        time: Math.floor(k.t / 1000),
+        open: Number(k.o),
+        high: Number(k.h),
+        low: Number(k.l),
+        close: Number(k.c),
+        volume: Number(k.v),
+        isClosed: k.x,
+      });
     }
   }
 
@@ -204,5 +236,9 @@ export class BinanceDataSource implements MarketDataSource {
 
   private emitTicker(ticker: NormalizedTicker): void {
     for (const cb of this.tickerCallbacks) cb(ticker);
+  }
+
+  private emitKlineUpdate(update: NormalizedKlineUpdate): void {
+    for (const cb of this.klineCallbacks) cb(update);
   }
 }

--- a/src/infra/binance/schemas.ts
+++ b/src/infra/binance/schemas.ts
@@ -51,10 +51,35 @@ export const MiniTickerEventSchema = z.object({
 });
 export type MiniTickerEventMsg = z.infer<typeof MiniTickerEventSchema>;
 
+/** Inner kline object from the @kline_* stream. */
+export const KlineDataSchema = z.object({
+  t: z.number(), // kline open time (ms)
+  T: z.number(), // kline close time (ms)
+  s: z.string(), // symbol
+  i: z.string(), // interval
+  o: z.string(), // open price
+  c: z.string(), // close price
+  h: z.string(), // high price
+  l: z.string(), // low price
+  v: z.string(), // base asset volume
+  n: z.number(), // number of trades
+  x: z.boolean(), // is kline closed
+});
+
+/** Binance WebSocket kline event (@kline_* stream). */
+export const KlineEventSchema = z.object({
+  e: z.literal("kline"),
+  E: z.number(), // event time
+  s: z.string(), // symbol
+  k: KlineDataSchema,
+});
+export type KlineEventMsg = z.infer<typeof KlineEventSchema>;
+
 /** Discriminated union for all stream messages this app consumes. */
 export const StreamMessageSchema = z.discriminatedUnion("e", [
   DepthUpdateSchema,
   AggTradeEventSchema,
   MiniTickerEventSchema,
+  KlineEventSchema,
 ]);
 export type StreamMessage = z.infer<typeof StreamMessageSchema>;

--- a/src/stores/market-data.test.ts
+++ b/src/stores/market-data.test.ts
@@ -41,6 +41,8 @@ function createMockSource() {
     }),
     getSnapshot: vi.fn(),
     fetchKlines: vi.fn().mockResolvedValue([]),
+    onKlineUpdate: vi.fn(),
+    subscribeKlineStream: vi.fn(),
   };
 
   return {
@@ -83,6 +85,7 @@ function resetStore() {
     orderBook: null,
     trades: [],
     klines: [],
+    klineIsLiveTick: false,
     connectionStatus: "disconnected",
     symbol: null,
   });

--- a/src/stores/market-data.ts
+++ b/src/stores/market-data.ts
@@ -4,6 +4,7 @@ import type { MarketDataSource } from "@/domain/market-data/MarketDataSource";
 import type {
   NormalizedCandle,
   NormalizedDepthUpdate,
+  NormalizedKlineUpdate,
   NormalizedSnapshot,
   NormalizedTicker,
   NormalizedTrade,
@@ -21,6 +22,8 @@ interface MarketDataState {
   trades: NormalizedTrade[];
   ticker: NormalizedTicker | null;
   klines: NormalizedCandle[];
+  /** true when klines was updated by a live WebSocket tick (last candle only); false on full REST load. */
+  klineIsLiveTick: boolean;
   connectionStatus: ConnectionStatus;
   symbol: string | null;
   symbolInfo: SymbolInfo | null;
@@ -98,6 +101,7 @@ export const useMarketDataStore = create<MarketDataState & MarketDataActions>((s
   trades: [],
   ticker: null,
   klines: [],
+  klineIsLiveTick: false,
   connectionStatus: "disconnected",
   symbol: null,
   symbolInfo: null,
@@ -128,6 +132,31 @@ export const useMarketDataStore = create<MarketDataState & MarketDataActions>((s
       set({ ticker });
     });
 
+    source.onKlineUpdate((update: NormalizedKlineUpdate) => {
+      set((state) => {
+        if (state.klines.length === 0) return state;
+        const candle: NormalizedCandle = {
+          time: update.time,
+          open: update.open,
+          high: update.high,
+          low: update.low,
+          close: update.close,
+          volume: update.volume,
+        };
+        if (update.isClosed) {
+          // Append the closed candle; ring-buffer to 500
+          const appended =
+            state.klines.length >= 500
+              ? [...state.klines.slice(1), candle]
+              : [...state.klines, candle];
+          return { klines: appended, klineIsLiveTick: false };
+        }
+        // Update the last (in-progress) candle with the latest tick
+        const updated = [...state.klines.slice(0, -1), candle];
+        return { klines: updated, klineIsLiveTick: true };
+      });
+    });
+
     set({ symbol, connectionStatus: "reconnecting" });
 
     // AC-1: connect (starts buffering) then immediately fetch snapshot
@@ -154,6 +183,7 @@ export const useMarketDataStore = create<MarketDataState & MarketDataActions>((s
       trades: [],
       ticker: null,
       klines: [],
+      klineIsLiveTick: false,
       connectionStatus: "disconnected",
       symbol: null,
       symbolInfo: null,
@@ -164,7 +194,9 @@ export const useMarketDataStore = create<MarketDataState & MarketDataActions>((s
     if (!_source) return;
     try {
       const klines = await _source.fetchKlines(symbol, interval, 500);
-      set({ klines });
+      set({ klines, klineIsLiveTick: false });
+      // Subscribe to live kline stream now that the interval is known.
+      _source.subscribeKlineStream(symbol, interval);
     } catch {
       // Network failure — leave existing klines in place
     }


### PR DESCRIPTION
## Summary

Two UI correctness fixes: real-time candlestick chart updates and full-row order book depth visualization.

### Fix 1: Price chart real-time updates (Closes #154)

**Problem:** Chart showed a static REST snapshot; candles never updated.

**Solution:** After `loadKlines()` fetches historical data, `subscribeKlineStream()` reconnects the combined WebSocket to include the `@kline_<interval>` sub-stream. Live ticks update the last candle via `series.update()` (no scroll jump). Closed candles are appended to the ring buffer (max 500).

Key design decisions:
- `wsClient.connect()` closes the old WS silently (no `onDisconnect` fired), so depth/trade/ticker streams reconnect without disrupting the reconnect manager
- `klineIsLiveTick: boolean` in store state lets the chart choose `update()` vs `setData()` without inspecting array contents
- `onKlineUpdate` / `subscribeKlineStream` added to `MarketDataSource` port (hexagonal boundary maintained)

### Fix 2: Order book depth bar spans full row (Closes #155)

**Problem:** Depth fill only covered the price column; `DepthBar` was absolute-positioned inside `<td className="relative">`.

**Solution:** Removed `DepthBar` from the row. Applied `background-image: linear-gradient(to left, color-mix(...) N%, transparent N%)` directly on `<tr>`. `background-image` and `background-color` are separate CSS properties, so `hover:bg-muted` continues to work on hover.

## Test Results

344 tests passing, 0 failures. Row test updated to assert `backgroundImage` on `<tr>`.

## Closes

Closes #154
Closes #155
