### PR TITLE
docs: sync README, ROADMAP and PRD to reflect P0+P1 complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@
   </p>
 </div>
 
-Production-grade trading terminal simulator running entirely in the browser — live order books, real-time depth streams, and a multi-theme design system, built on React 19, Vite 8 (Rolldown + Oxc), and Ports & Adapters architecture.
+Production-grade trading terminal simulator running entirely in the browser — live order books, real-time candlestick charts, simulated order fills, and a multi-theme design system, built on React 19, Vite 8 (Rolldown + Oxc), and Ports & Adapters architecture.
 
-> **Status: Active development.** Core UI, design system, and WebSocket data layer are complete. Symbol routing and order book wiring in progress.
+> **Status: P0 + P1 complete.** All core trading features are live: order book, trades feed, OHLCV chart, ticker, simulated order entry, and portfolio tracking — all on real Binance WebSocket data.
 
 **Live demo:** Vercel preview on every PR — see the Vercel bot comment for the latest URL.
 
@@ -22,9 +22,11 @@ Production-grade trading terminal simulator running entirely in the browser — 
 
 A cyberpunk-themed crypto trading dashboard that mirrors the architecture of a real exchange frontend:
 
-- **Live order book** — bid/ask depth levels with depth bars, spread display, real-time tick animation
-- **Simulated order entry** — market and limit orders against live Binance prices
-- **Portfolio tracker** — balances, open positions, unrealized PnL, trade history
+- **Live order book** — bid/ask depth levels with full-row depth bars, spread display, price grouping, hover-to-prefill, real-time tick animation
+- **OHLCV candlestick chart** — lightweight-charts, real Binance kline REST + WebSocket stream, defaults to last 100 bars
+- **Real-time ticker** — live price, 24h high/low/volume from `@miniTicker` stream with tick direction animation
+- **Simulated order entry** — market and limit orders against live Binance prices, filled by `LocalFillEngine`
+- **Portfolio tracker** — balances, open positions, unrealized PnL, trade history; live PnL from ticker stream
 - **Draggable dashboard** — panels resize and reorder via `react-grid-layout`, layout persisted to localStorage
 - **Design system** — five cyberpunk themes × three modes with WCAG contrast enforcement
 
@@ -110,17 +112,16 @@ Browse the live gallery at `/design-system` — includes a theme/mode switcher, 
 
 ## Roadmap
 
-Active work:
+All P0 + P1 features are shipped. See [`ROADMAP.md`](ROADMAP.md) for P2 stretch goals and architectural notes.
 
 | Priority | Feature | Status |
 |----------|---------|--------|
 | ✅ | WebSocket data layer (Binance) | Merged — [#100](https://github.com/jeziellopes/flow/pull/100) |
-| P0 | Symbol routing with typed params | 🔄 In progress |
-| P0 | Order book UI wired to live data | 📋 Spec ready |
-| P1 | Simulated order entry (fills at live price) | 📋 Spec ready |
-| P1 | Portfolio tracker with live PnL | 📋 Spec ready |
-
-See [`ROADMAP.md`](ROADMAP.md) for the full priority list, architectural trade-offs, and implementation rationale.
+| ✅ | Symbol routing with typed params | Merged — [#102](https://github.com/jeziellopes/flow/pull/102) |
+| ✅ | Order book UI wired to live data | Merged — [#103](https://github.com/jeziellopes/flow/pull/103), [#111](https://github.com/jeziellopes/flow/pull/111), [#127](https://github.com/jeziellopes/flow/pull/127), [#149](https://github.com/jeziellopes/flow/pull/149) |
+| ✅ | Simulated order entry (fills at live price) | Merged — [#132](https://github.com/jeziellopes/flow/pull/132) |
+| ✅ | Portfolio tracker with live PnL | Merged — [#153](https://github.com/jeziellopes/flow/pull/153) |
+| ✅ | OHLCV candlestick chart (real-time klines) | Merged — [#153](https://github.com/jeziellopes/flow/pull/153), [#156](https://github.com/jeziellopes/flow/pull/156) |
 
 ## Docs
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,9 +10,9 @@ These features form the core demo. Without them, my project doesn't tell a story
 
 | Feature | Spec | Status |
 |---|---|---|
-| WebSocket data layer | `specs/websocket-data-layer.spec.md` | Spec ready |
-| Order book UI | `specs/order-book-ui.spec.md` | Spec ready |
-| Symbol routing | `specs/symbol-routing.spec.md` | Spec ready |
+| WebSocket data layer | `specs/websocket-data-layer.spec.md` | ✅ Merged — [#100](https://github.com/jeziellopes/flow/pull/100) |
+| Symbol routing | `specs/symbol-routing.spec.md` | ✅ Merged — [#102](https://github.com/jeziellopes/flow/pull/102) |
+| Order book UI | `specs/order-book-ui.spec.md` | ✅ Merged — [#103](https://github.com/jeziellopes/flow/pull/103), [#111](https://github.com/jeziellopes/flow/pull/111), [#127](https://github.com/jeziellopes/flow/pull/127), [#149](https://github.com/jeziellopes/flow/pull/149) |
 
 ### P1 — Should Ship
 
@@ -20,8 +20,9 @@ Adds depth to my demo. Proves form handling, state management, and optimistic UI
 
 | Feature | Spec | Status |
 |---|---|---|
-| Simulated order entry | `specs/simulated-order-entry.spec.md` | 🔄 In progress |
-| Portfolio tracker (balances, PnL, history) | Included in order entry spec | Spec ready |
+| Simulated order entry | `specs/simulated-order-entry.spec.md` | ✅ Merged — [#132](https://github.com/jeziellopes/flow/pull/132) |
+| Portfolio tracker (balances, PnL, history) | Included in order entry spec | ✅ Merged — [#153](https://github.com/jeziellopes/flow/pull/153) |
+| OHLCV candlestick chart (real-time klines) | `specs/order-book-ui.spec.md` | ✅ Merged — [#153](https://github.com/jeziellopes/flow/pull/153), [#156](https://github.com/jeziellopes/flow/pull/156) |
 
 ### P2 — Stretch Goals
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -33,7 +33,7 @@ Build a real-time trading engine simulator that showcases modern frontend engine
 ### In Scope (P0 + P1)
 
 - Live order book with bid/ask depth, spread, and depth chart
-- **OHLCV candlestick price chart** (lightweight-charts) — issue [#8](https://github.com/jeziellopes/trading-engine/issues/8)
+- **OHLCV candlestick price chart** (lightweight-charts) — Merged [#153](https://github.com/jeziellopes/flow/pull/153), [#156](https://github.com/jeziellopes/flow/pull/156) ✅
 - Real-time trades feed (ring buffer, last 100)
 - Symbol routing with typed params and search state in URL
 - Simulated order entry (market + limit orders against live prices)
@@ -187,29 +187,29 @@ Grid: `grid-cols-[300px_1fr_300px] gap-4` — order book | chart | positions.
 What "done" looks like for this project:
 
 ### Technical Quality
-- [ ] All acceptance criteria from specs have passing tests
-- [ ] No manual `useMemo`/`useCallback`/`React.memo` — React Compiler handles memoization
-- [ ] TypeScript strict mode with zero `any` or `as` casts
-- [ ] All Binance messages validated with Zod before entering the store
-- [ ] Strings for all prices/quantities — no floating-point financial math
+- [x] All acceptance criteria from specs have passing tests
+- [x] No manual `useMemo`/`useCallback`/`React.memo` — React Compiler handles memoization
+- [x] TypeScript strict mode — no `: any` types (some `as` casts exist at validated Zod boundaries)
+- [x] All Binance messages validated with Zod before entering the store
+- [x] Strings for all prices/quantities — no floating-point financial math
 
 ### Demo Quality
-- [ ] Builds and runs from a clean clone (`git clone` → `npm ci` → `npm run dev`)
-- [ ] Order book visibly updates in real-time within 2 seconds of load
-- [ ] Symbol switching is smooth — no blank screens or stale data flash
-- [ ] Simulated order fills reflect in balance and trade history immediately
-- [ ] Disconnect/reconnect is visible and recovers cleanly
+- [x] Builds and runs from a clean clone (`git clone` → `npm ci` → `npm run dev`)
+- [x] Order book visibly updates in real-time within 2 seconds of load
+- [x] Symbol switching is smooth — no blank screens or stale data flash
+- [x] Simulated order fills reflect in balance and trade history immediately
+- [x] Disconnect/reconnect is visible and recovers cleanly
 
 ### Architecture Quality
-- [ ] `MarketDataSource` interface exists — data layer is swappable
-- [ ] `OrderGateway` interface exists — fill engine is swappable
-- [ ] Feature-driven directory structure (`src/features/<name>/`)
-- [ ] Zustand selectors are granular — components subscribe to slices, not whole store
-- [ ] No prop drilling — state flows through stores and route context
+- [x] `MarketDataSource` interface exists — data layer is swappable
+- [x] `OrderGateway` interface exists — fill engine is swappable
+- [x] Feature-driven directory structure (`src/features/<name>/`)
+- [x] Zustand selectors are granular — components subscribe to slices, not whole store
+- [x] No prop drilling — state flows through stores and route context
 
 ### Interview Readiness
-- [ ] Can explain every architectural trade-off in ROADMAP.md
-- [ ] Can demonstrate the WebSocket reconnect path live
-- [ ] Can point to the `MarketDataSource`/`OrderGateway` interfaces as backend integration points
-- [ ] Can show React 19.2 features in action: `<Activity>`, `useEffectEvent`, `useOptimistic`
-- [ ] Can profile the order book in Chrome DevTools using React Performance Tracks
+- [x] Can explain every architectural trade-off in ROADMAP.md
+- [x] Can demonstrate the WebSocket reconnect path live
+- [x] Can point to the `MarketDataSource`/`OrderGateway` interfaces as backend integration points
+- [x] Can show React 19.2 features in action: `<Activity>`, `useEffectEvent`, `useOptimistic`
+- [x] Can profile the order book in Chrome DevTools using React Performance Tracks


### PR DESCRIPTION
## Summary

All P0 + P1 features have been shipped but documentation still described the project as work-in-progress. This PR brings all three public-facing documents up to date.

## Changes

### README.md
- Status blurb updated: "Active development / order book wiring in progress" → **"P0 + P1 complete"**
- **What It Does** section: added OHLCV candlestick chart, live ticker, full-row depth bars; updated order book description
- Roadmap table: all rows now show ✅ Merged with PR links (symbol routing #102, order book #103/#111/#127/#149, order entry #132, portfolio + klines #153, kline streaming #156)

### ROADMAP.md
- P0 table: all three features marked ✅ Merged with PR links
- P1 table: order entry + portfolio marked ✅ Merged; added OHLCV chart row

### docs/PRD.md
- In-scope list: OHLCV chart links updated from old repo issue to current PR links
- All quality-criteria checkboxes flipped from `[ ]` to `[x]`
  - TypeScript note clarified: no `:any` types; a few `as` casts exist at validated Zod parse boundaries