### PR TITLE
ci(release): auto-open back-merge PR after stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -30,6 +33,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Run Semantic Release
+        id: semantic
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
@@ -37,3 +41,50 @@ jobs:
           GIT_AUTHOR_EMAIL: semantic-release-bot@martynus.net
           GIT_COMMITTER_NAME: semantic-release-bot
           GIT_COMMITTER_EMAIL: semantic-release-bot@martynus.net
+
+  # After a stable release lands on main, open a back-merge PR so develop stays
+  # in sync. Without this, the next develop → main PR always conflicts on
+  # CHANGELOG.md and package.json (the two files semantic-release auto-commits).
+  backmerge:
+    name: Open back-merge PR (main → develop)
+    needs: release
+    if: |
+      github.ref == 'refs/heads/main' &&
+      needs.release.outputs.new_release_published == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Create back-merge PR
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          VERSION: ${{ needs.release.outputs.new_release_version }}
+        run: |
+          cat > /tmp/backmerge-body.md << 'EOF'
+          ## Why this PR exists
+
+          Semantic-release committed `chore(release): ${VERSION}` directly to `main`
+          after the stable release. That commit updates `CHANGELOG.md` and `package.json`
+          but is never automatically reflected in `develop`, causing conflicts on the
+          next `develop → main` promotion PR.
+
+          ## Resolution
+          - `CHANGELOG.md` — keep `develop`'s version; semantic-release will regenerate for the next stable
+          - `package.json` — keep `develop`'s pre-release version; semantic-release will set the next version
+
+          Merge this promptly so `develop` stays in sync with `main`.
+          EOF
+          sed -i "s/\${VERSION}/${VERSION}/g" /tmp/backmerge-body.md
+          gh pr create \
+            --base develop \
+            --head main \
+            --title "chore(sync): back-merge main into develop after v${VERSION}" \
+            --label chore \
+            --body-file /tmp/backmerge-body.md \
+          || echo "PR already exists or no changes needed"


### PR DESCRIPTION
## Problem

Every time semantic-release creates a stable release on `main`, it pushes a `chore(release): X.Y.Z` commit directly to `main` updating `CHANGELOG.md` and `package.json`. This commit never lands in `develop`, so the next `develop → main` PR always conflicts on those two files. This just happened with v1.1.0 (see #163).

## Solution

Adds a `backmerge` job to `release.yml` that fires only when:
- The push was to `main` (`github.ref == 'refs/heads/main'`)
- Semantic-release actually published a new release (`new_release_published == 'true'`)

The job opens a `chore(sync): back-merge main into develop after vX.Y.Z` PR automatically, so the back-merge never gets forgotten.

## Notes
- Uses `--body-file` to avoid YAML literal-block-scalar indentation issues
- `|| echo` fallback prevents workflow failure if a PR already exists (idempotent)
- The `release` job now exposes `new_release_published` + `new_release_version` outputs via `id: semantic`