### PR TITLE
chore(release): remove @semantic-release/git plugin + rename package to flow

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,15 +6,7 @@
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     ["@semantic-release/npm", { "npmPublish": false }],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}\n\nSigned-off-by: semantic-release-bot <semantic-release-bot@martynus.net>"
-      }
-    ],
     "@semantic-release/github"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "trading-engine",
+  "name": "flow",
   "private": true,
   "version": "1.1.0-next.26",
   "type": "module",


### PR DESCRIPTION
## Problem

`@semantic-release/git` auto-commits `CHANGELOG.md` + `package.json` directly to `main` after every stable release. That commit is never in `develop`, so every subsequent `develop → main` PR conflicts on those two files (this just happened with v1.1.0, requiring back-merge PR #163).

## Changes

- **Remove `@semantic-release/git`** — semantic-release still creates git tags, publishes GitHub releases, and generates release notes. It just no longer writes files back to the repo. No auto-commit = no conflict = no back-merge ever needed.
- **Remove `@semantic-release/changelog`** — only useful alongside the git plugin; pointless without something to commit it.
- **Rename `package.name` from `trading-engine` → `flow`** — aligns with the repo/project name.

## After this merges

PR #163 (back-merge to resolve the current conflict) still needs to land before PR #162 (develop → main). Once #162 merges, v1.2.0 is tagged and released — no files are committed back to main, so the next release cycle starts clean.